### PR TITLE
Add more Trait Interfaces

### DIFF
--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -620,6 +620,22 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> PositionGetta
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
     type NativePositionType = CellIndex<T>;
+
+    fn position_is_snake_body(&self, pos: Self::NativePositionType) -> bool {
+        let cell = self.get_cell(pos);
+
+        cell.is_body_segment()
+    }
+
+    fn position_from_native(&self, pos: Self::NativePositionType) -> Position {
+        let width = Self::width();
+
+        pos.into_position(width)
+    }
+
+    fn native_from_position(&self, pos: Position) -> Self::NativePositionType {
+        Self::NativePositionType::new(pos, Self::width())
+    }
 }
 
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HeadGettableGame
@@ -682,6 +698,10 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> LengthGettabl
     fn get_length(&self, snake_id: &Self::SnakeIDType) -> Self::LengthType {
         self.lengths[snake_id.0.as_usize()]
     }
+
+    fn get_length_i64(&self, snake_id: &Self::SnakeIDType) -> i64 {
+        self.get_length(*snake_id) as i64
+    }
 }
 
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HealthGettableGame
@@ -693,13 +713,15 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HealthGettabl
     fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType {
         self.healths[snake_id.0.as_usize()]
     }
+
+    fn get_health_i64(&self, snake_id: &Self::SnakeIDType) -> i64 {
+        self.get_health(*snake_id) as i64
+    }
 }
 
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> VictorDeterminableGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
-    type SnakeIDType = SnakeId;
-
     fn is_over(&self) -> bool {
         self.healths[0] == 0 || self.healths.iter().filter(|h| **h != 0).count() <= 1
     }
@@ -731,8 +753,6 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> VictorDetermi
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> RandomReasonableMovesGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
-    type SnakeIDType = SnakeId;
-
     fn random_reasonable_move_for_each_snake(&self) -> Vec<(Self::SnakeIDType, Move)> {
         let width = Self::width();
         self.healths
@@ -764,8 +784,6 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> RandomReasona
 impl<T: SimulatorInstruments, N: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
     SimulableGame<T> for CellBoard<N, BOARD_SIZE, MAX_SNAKES>
 {
-    type SnakeIDType = SnakeId;
-
     #[allow(clippy::type_complexity)]
     fn simulate_with_moves(
         &self,

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -31,6 +31,8 @@ pub trait CellNum:
     fn as_usize(&self) -> usize;
     /// makes a cellnum from an i32
     fn from_i32(i: i32) -> Self;
+    /// makes a cellnum from an usize
+    fn from_usize(i: usize) -> Self;
 }
 
 impl CellNum for u8 {
@@ -41,6 +43,10 @@ impl CellNum for u8 {
     fn from_i32(i: i32) -> Self {
         i as u8
     }
+
+    fn from_usize(i: usize) -> Self {
+        i as u8
+    }
 }
 impl CellNum for u16 {
     fn as_usize(&self) -> usize {
@@ -48,6 +54,10 @@ impl CellNum for u16 {
     }
 
     fn from_i32(i: i32) -> Self {
+        i as u16
+    }
+
+    fn from_usize(i: usize) -> Self {
         i as u16
     }
 }
@@ -665,16 +675,18 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> FoodGettableG
     fn get_all_food_as_positions(&self) -> Vec<crate::wire_representation::Position> {
         self.cells
             .iter()
-            .filter(|c| c.is_food())
-            .map(|c| c.idx.into_position(Self::width()))
+            .enumerate()
+            .filter(|(_, c)| c.is_food())
+            .map(|(i, _)| CellIndex(T::from_usize(i)).into_position(Self::width()))
             .collect()
     }
 
     fn get_all_food_as_native_positions(&self) -> Vec<Self::NativePositionType> {
         self.cells
             .iter()
-            .filter(|c| c.is_food())
-            .map(|c| c.idx)
+            .enumerate()
+            .filter(|(_, c)| c.is_food())
+            .map(|(i, _)| CellIndex(T::from_usize(i)))
             .collect()
     }
 }

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -595,7 +595,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
     }
 
     /// determin the width of the CellBoard
-    fn width() -> u8 {
+    pub fn width() -> u8 {
         (BOARD_SIZE as f32).sqrt() as u8
     }
 }

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -3,8 +3,8 @@
 /// cast from a json represention to a `CellBoard`
 use crate::types::{
     FoodGettableGame, HeadGettableGame, HealthGettabkeGame, LengthGettableGame,
-    RandomReasonableMovesGame, SnakeIDGettableGame, SnakeIDMap, SnakeId, VictorDeterminableGame,
-    YouDeterminableGame,
+    PositionGettableGame, RandomReasonableMovesGame, SnakeIDGettableGame, SnakeIDMap, SnakeId,
+    VictorDeterminableGame, YouDeterminableGame,
 };
 use crate::wire_representation::Game;
 use fxhash::FxHashSet;
@@ -52,7 +52,7 @@ impl CellNum for u16 {
 }
 
 /// wrapper type for an index in to the board
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[repr(transparent)]
 pub struct CellIndex<T: CellNum>(pub T);
 
@@ -616,11 +616,15 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SnakeIDGettab
     }
 }
 
-impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HeadGettableGame
+impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> PositionGettableGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
     type NativePositionType = CellIndex<T>;
+}
 
+impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HeadGettableGame
+    for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
+{
     fn get_head_as_position(
         &self,
         snake_id: &Self::SnakeIDType,
@@ -641,8 +645,6 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HeadGettableG
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> FoodGettableGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
-    type NativePositionType = CellIndex<T>;
-
     fn get_all_food_as_positions(&self) -> Vec<crate::wire_representation::Position> {
         self.cells
             .iter()

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -1,12 +1,12 @@
 //! A compact board representation that is efficient for simulation
-/// you almost certainly want to use the `convert_from_game` method to
-/// cast from a json represention to a `CellBoard`
-use crate::types::NeighborDeterminableGame;
 use crate::types::{
     FoodGettableGame, HeadGettableGame, HealthGettableGame, LengthGettableGame,
     PositionGettableGame, RandomReasonableMovesGame, SnakeIDGettableGame, SnakeIDMap, SnakeId,
     VictorDeterminableGame, YouDeterminableGame,
 };
+/// you almost certainly want to use the `convert_from_game` method to
+/// cast from a json represention to a `CellBoard`
+use crate::types::{NeighborDeterminableGame, SnakeBodyGettableGame};
 use crate::wire_representation::Game;
 use fxhash::FxHashSet;
 use itertools::Itertools;
@@ -988,6 +988,23 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> NeighborDeter
             .filter(|(new_head, _)| !self.off_board(*new_head, width))
             .map(|(_, ci)| ci)
             .collect()
+    }
+}
+
+impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SnakeBodyGettableGame
+    for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
+{
+    fn get_snake_body_vec(&self, snake_id: &Self::SnakeIDType) -> Vec<Self::NativePositionType> {
+        let mut body = vec![];
+        body.reserve(self.get_length(*snake_id).into());
+        let mut cur = Some(self.get_head_as_native_position(snake_id));
+
+        while let Some(c) = cur {
+            body.push(c);
+            cur = self.get_cell(c).get_next_index();
+        }
+
+        body
     }
 }
 

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -2,7 +2,7 @@
 /// you almost certainly want to use the `convert_from_game` method to
 /// cast from a json represention to a `CellBoard`
 use crate::types::{
-    FoodGettableGame, HeadGettableGame, HealthGettabkeGame, LengthGettableGame,
+    FoodGettableGame, HeadGettableGame, HealthGettableGame, LengthGettableGame,
     PositionGettableGame, RandomReasonableMovesGame, SnakeIDGettableGame, SnakeIDMap, SnakeId,
     VictorDeterminableGame, YouDeterminableGame,
 };
@@ -665,8 +665,6 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> FoodGettableG
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> YouDeterminableGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
-    type SnakeIDType = SnakeId;
-
     fn is_you(&self, snake_id: &Self::SnakeIDType) -> bool {
         snake_id.0 == 0
     }
@@ -686,10 +684,11 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> LengthGettabl
     }
 }
 
-impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HealthGettabkeGame
+impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> HealthGettableGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
     type HealthType = u8;
+    const ZERO: Self::HealthType = 0;
 
     fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType {
         self.healths[snake_id.0.as_usize()]

--- a/src/types.rs
+++ b/src/types.rs
@@ -167,17 +167,21 @@ pub trait VictorDeterminableGame: std::fmt::Debug {
     fn get_winner(&self) -> Option<Self::SnakeIDType>;
 }
 
+/// This represents a single move for a single snake
+pub type SnakeMove<T> = (T, Move);
+
 /// a game for which future states can be simulated
 pub trait SimulableGame<T: SimulatorInstruments>: std::fmt::Debug + Sized {
     #[allow(missing_docs)]
     type SnakeIDType;
+
     /// simulates all possible future games for a given game returning the snake ids, moves that
     /// got to a given state, plus that state
     fn simulate(
         &self,
         instruments: &T,
         snake_ids: Vec<Self::SnakeIDType>,
-    ) -> Vec<(Vec<(Self::SnakeIDType, Move)>, Self)> {
+    ) -> Vec<(Vec<SnakeMove<Self::SnakeIDType>>, Self)> {
         let moves_to_simulate = Move::all();
         let build = snake_ids
             .into_iter()
@@ -191,7 +195,7 @@ pub trait SimulableGame<T: SimulatorInstruments>: std::fmt::Debug + Sized {
         &self,
         instruments: &T,
         snake_ids_and_moves: Vec<(Self::SnakeIDType, Vec<Move>)>,
-    ) -> Vec<(Vec<(Self::SnakeIDType, Move)>, Self)>;
+    ) -> Vec<(Vec<SnakeMove<Self::SnakeIDType>>, Self)>;
 }
 
 /// A game for which the head of the current snake can be got.
@@ -200,10 +204,14 @@ pub trait HeadGettableGame: SnakeIDGettableGame {
     type NativePositionType;
 
     /// get the head position for a given snake id, as a position struct (slow for simulation)
-    fn get_head_as_position(&self, snake_id: &Self::SnakeIDType) -> crate::wire_representation::Position;
-    
+    fn get_head_as_position(
+        &self,
+        snake_id: &Self::SnakeIDType,
+    ) -> crate::wire_representation::Position;
+
     /// get the head position for a given snake as some "native" type for this game
-    fn get_head_as_native_position(&self, snake_id: &Self::SnakeIDType) -> Self::NativePositionType;
+    fn get_head_as_native_position(&self, snake_id: &Self::SnakeIDType)
+        -> Self::NativePositionType;
 }
 
 /// a game for which random reasonable moves for a given snake can be determined. e.g. do not collide with yourself

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,10 @@
 //! various types that are useful for working with battlesnake
 use crate::wire_representation::Game;
+use serde::Serialize;
+use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
-use serde::{Serialize, Serializer};
 
 /// Represents the snake IDs for a given game. This should be established once on the `/start` request and then
 /// stored, so that `SnakeIds` are stable throughout the game.
@@ -19,7 +20,7 @@ pub struct Vector {
 }
 
 /// Represents a move
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum Move {
     #[allow(missing_docs)]
     Left,
@@ -212,6 +213,36 @@ pub trait HeadGettableGame: SnakeIDGettableGame {
     /// get the head position for a given snake as some "native" type for this game
     fn get_head_as_native_position(&self, snake_id: &Self::SnakeIDType)
         -> Self::NativePositionType;
+}
+
+/// A game for which the food on the board can be queries
+pub trait FoodGettableGame: SnakeIDGettableGame {
+    /// the native position type for this board
+    type NativePositionType;
+
+    /// get the head position for a given snake id, as a position struct (slow for simulation)
+    fn get_all_food_as_positions(&self) -> Vec<crate::wire_representation::Position>;
+
+    /// get the head position for a given snake as some "native" type for this game
+    fn get_all_food_as_native_positions(&self) -> Vec<Self::NativePositionType>;
+}
+
+/// A game for which the length of the current snake can be got.
+pub trait LengthGettableGame: SnakeIDGettableGame {
+    /// the length type for this game
+    type LengthType;
+
+    /// get the length for a given snake
+    fn get_length(&self, snake_id: &Self::SnakeIDType) -> Self::LengthType;
+}
+
+/// A game for which the length of the current snake can be got.
+pub trait HealthGettabkeGame: SnakeIDGettableGame {
+    /// the length type for this game
+    type HealthType;
+
+    /// get the length for a given snake
+    fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType;
 }
 
 /// a game for which random reasonable moves for a given snake can be determined. e.g. do not collide with yourself

--- a/src/types.rs
+++ b/src/types.rs
@@ -236,12 +236,12 @@ pub trait LengthGettableGame: SnakeIDGettableGame {
     fn get_length(&self, snake_id: &Self::SnakeIDType) -> Self::LengthType;
 }
 
-/// A game for which the length of the current snake can be got.
+/// A game for which the health of the current snake can be got.
 pub trait HealthGettabkeGame: SnakeIDGettableGame {
-    /// the length type for this game
+    /// the health type for this game
     type HealthType;
 
-    /// get the length for a given snake
+    /// get the health for a given snake
     fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType;
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,6 +54,17 @@ impl Move {
         }
     }
 
+    /// create a Move from the given vector
+    pub fn from_vector(vector: Vector) -> Self {
+        match vector {
+            Vector { x: -1, y: 0 } => Self::Left,
+            Vector { x: 1, y: 0 } => Self::Right,
+            Vector { x: 0, y: 1 } => Self::Up,
+            Vector { x: 0, y: -1 } => Self::Down,
+            _ => panic!(),
+        }
+    }
+
     /// returns a vec of all possible moves
     pub fn all() -> Vec<Move> {
         vec![Move::Up, Move::Down, Move::Left, Move::Right]
@@ -146,10 +157,7 @@ pub trait SimulatorInstruments: std::fmt::Debug {
 }
 
 /// A game for which "you" is determinable
-pub trait YouDeterminableGame: std::fmt::Debug {
-    #[allow(missing_docs)]
-    type SnakeIDType;
-
+pub trait YouDeterminableGame: std::fmt::Debug + SnakeIDGettableGame {
     /// determines for a given game if a given snake id is you.
     fn is_you(&self, snake_id: &Self::SnakeIDType) -> bool;
 
@@ -237,12 +245,20 @@ pub trait LengthGettableGame: SnakeIDGettableGame {
 }
 
 /// A game for which the health of the current snake can be got.
-pub trait HealthGettabkeGame: SnakeIDGettableGame {
+pub trait HealthGettableGame: SnakeIDGettableGame {
     /// the health type for this game
-    type HealthType;
+    type HealthType: PartialEq;
+
+    /// A constant that defines what zero health means for the given game
+    const ZERO: Self::HealthType;
 
     /// get the health for a given snake
     fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType;
+
+    /// check wheterh a given snake is alive
+    fn is_alive(&self, snake_id: &Self::SnakeIDType) -> bool {
+        self.get_health(snake_id) == Self::ZERO
+    }
 }
 
 /// a game for which random reasonable moves for a given snake can be determined. e.g. do not collide with yourself

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 //! various types that are useful for working with battlesnake
-use crate::wire_representation::Game;
+use crate::wire_representation::{Game, Position};
 use serde::{Serialize, Serializer};
 use std::collections::HashMap;
-use std::fmt;
+use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::time::Duration;
 
@@ -145,7 +145,8 @@ pub fn build_snake_id_map(g: &Game) -> SnakeIDMap {
 /// A game for which one can get the snake ids
 pub trait SnakeIDGettableGame {
     #[allow(missing_docs)]
-    type SnakeIDType;
+    type SnakeIDType: PartialEq + Debug + Serialize + Eq + Hash + Clone + Send;
+
     #[allow(missing_docs)]
     fn get_snake_ids(&self) -> Vec<Self::SnakeIDType>;
 }
@@ -166,9 +167,7 @@ pub trait YouDeterminableGame: std::fmt::Debug + SnakeIDGettableGame {
 }
 
 /// A game which can have it's winner determined
-pub trait VictorDeterminableGame: std::fmt::Debug {
-    #[allow(missing_docs)]
-    type SnakeIDType;
+pub trait VictorDeterminableGame: std::fmt::Debug + SnakeIDGettableGame {
     #[allow(missing_docs)]
     fn is_over(&self) -> bool;
 
@@ -180,10 +179,9 @@ pub trait VictorDeterminableGame: std::fmt::Debug {
 pub type SnakeMove<T> = (T, Move);
 
 /// a game for which future states can be simulated
-pub trait SimulableGame<T: SimulatorInstruments>: std::fmt::Debug + Sized {
-    #[allow(missing_docs)]
-    type SnakeIDType;
-
+pub trait SimulableGame<T: SimulatorInstruments>:
+    std::fmt::Debug + Sized + SnakeIDGettableGame
+{
     /// simulates all possible future games for a given game returning the snake ids, moves that
     /// got to a given state, plus that state
     fn simulate(
@@ -210,7 +208,16 @@ pub trait SimulableGame<T: SimulatorInstruments>: std::fmt::Debug + Sized {
 /// A game for which board positions can be identified and returned
 pub trait PositionGettableGame {
     /// the native position type for this board
-    type NativePositionType: Eq + Hash;
+    type NativePositionType: Eq + Hash + Clone + Ord + PartialOrd + Debug;
+
+    /// Check if the given position is a snake body
+    fn position_is_snake_body(&self, pos: Self::NativePositionType) -> bool;
+
+    /// Convert a position to the native type
+    fn position_from_native(&self, native: Self::NativePositionType) -> Position;
+
+    /// Convert a position to the native type
+    fn native_from_position(&self, pos: Position) -> Self::NativePositionType;
 }
 
 /// A game for which the head of the current snake can be got.
@@ -238,10 +245,13 @@ pub trait FoodGettableGame: PositionGettableGame + SnakeIDGettableGame {
 /// A game for which the length of the current snake can be got.
 pub trait LengthGettableGame: SnakeIDGettableGame {
     /// the length type for this game
-    type LengthType;
+    type LengthType: Ord + PartialOrd;
 
     /// get the length for a given snake
     fn get_length(&self, snake_id: &Self::SnakeIDType) -> Self::LengthType;
+
+    /// get the length for a given snake
+    fn get_length_i64(&self, snake_id: &Self::SnakeIDType) -> i64;
 }
 
 /// A game for which the health of the current snake can be got.
@@ -255,16 +265,17 @@ pub trait HealthGettableGame: SnakeIDGettableGame {
     /// get the health for a given snake
     fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType;
 
+    /// get the health for a given snake as an i64
+    fn get_health_i64(&self, snake_id: &Self::SnakeIDType) -> i64;
+
     /// check wheterh a given snake is alive
     fn is_alive(&self, snake_id: &Self::SnakeIDType) -> bool {
-        self.get_health(snake_id) == Self::ZERO
+        self.get_health(snake_id) != Self::ZERO
     }
 }
 
 /// a game for which random reasonable moves for a given snake can be determined. e.g. do not collide with yourself
-pub trait RandomReasonableMovesGame {
-    #[allow(missing_docs)]
-    type SnakeIDType;
+pub trait RandomReasonableMovesGame: SnakeIDGettableGame {
     #[allow(missing_docs)]
     fn random_reasonable_move_for_each_snake(&self) -> Vec<(Self::SnakeIDType, Move)>;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 //! various types that are useful for working with battlesnake
 use crate::wire_representation::Game;
-use serde::Serialize;
 use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 use std::fmt;

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 use std::fmt;
+use std::hash::Hash;
 use std::time::Duration;
 
 /// Represents the snake IDs for a given game. This should be established once on the `/start` request and then
@@ -199,11 +200,14 @@ pub trait SimulableGame<T: SimulatorInstruments>: std::fmt::Debug + Sized {
     ) -> Vec<(Vec<SnakeMove<Self::SnakeIDType>>, Self)>;
 }
 
-/// A game for which the head of the current snake can be got.
-pub trait HeadGettableGame: SnakeIDGettableGame {
+/// A game for which board positions can be identified and returned
+pub trait PositionGettableGame {
     /// the native position type for this board
-    type NativePositionType;
+    type NativePositionType: Eq + Hash;
+}
 
+/// A game for which the head of the current snake can be got.
+pub trait HeadGettableGame: PositionGettableGame + SnakeIDGettableGame {
     /// get the head position for a given snake id, as a position struct (slow for simulation)
     fn get_head_as_position(
         &self,
@@ -216,10 +220,7 @@ pub trait HeadGettableGame: SnakeIDGettableGame {
 }
 
 /// A game for which the food on the board can be queries
-pub trait FoodGettableGame: SnakeIDGettableGame {
-    /// the native position type for this board
-    type NativePositionType;
-
+pub trait FoodGettableGame: PositionGettableGame + SnakeIDGettableGame {
     /// get the head position for a given snake id, as a position struct (slow for simulation)
     fn get_all_food_as_positions(&self) -> Vec<crate::wire_representation::Position>;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -279,3 +279,41 @@ pub trait RandomReasonableMovesGame: SnakeIDGettableGame {
     #[allow(missing_docs)]
     fn random_reasonable_move_for_each_snake(&self) -> Vec<(Self::SnakeIDType, Move)>;
 }
+
+/// a game for which the neighbors of a given Position can be determined
+pub trait NeighborDeterminableGame: PositionGettableGame {
+    /// returns the neighboring positions
+    fn neighbors(&self, pos: &Self::NativePositionType) -> Vec<Self::NativePositionType>;
+
+    /// returns the neighboring positions, and the Move required to get to each
+    fn possible_moves(
+        &self,
+        pos: &Self::NativePositionType,
+    ) -> Vec<(Move, Self::NativePositionType)>;
+}
+
+/// a game for which each snakes shout can be determined
+pub trait ShoutGettableGame: SnakeIDGettableGame {
+    /// get the shout for a given snake, if they shouted this turn
+    fn get_shout(&self, snake_id: &Self::SnakeIDType) -> Option<String>;
+}
+
+/// a game for which the size of the game board can be determined
+pub trait SizeDeterminableGame {
+    #[allow(missing_docs)]
+    fn get_width(&self) -> u32;
+    #[allow(missing_docs)]
+    fn get_height(&self) -> u32;
+}
+
+/// a game for which the current turn is determinable
+pub trait TurnDeterminableGame {
+    #[allow(missing_docs)]
+    fn turn(&self) -> u64;
+}
+
+/// A game where an entire snake body is gettable
+pub trait SnakeBodyGettableGame: PositionGettableGame + SnakeIDGettableGame {
+    /// return a Vec of the positions for a given snake body, in order from head to tail
+    fn get_snake_body_vec(&self, snake_id: &Self::SnakeIDType) -> Vec<Self::NativePositionType>;
+}

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -4,7 +4,7 @@ mod simulator;
 
 use crate::compact_representation::{CellBoard, CellNum};
 use crate::types::{
-    FoodGettableGame, HealthGettabkeGame, LengthGettableGame, Move, PositionGettableGame,
+    FoodGettableGame, HealthGettableGame, LengthGettableGame, Move, PositionGettableGame,
     RandomReasonableMovesGame, SimulableGame, SimulatorInstruments, SnakeIDGettableGame,
     SnakeIDMap, SnakeMove, Vector, VictorDeterminableGame, YouDeterminableGame,
 };
@@ -23,6 +23,7 @@ pub struct BattleSnake {
     pub head: Position,
     pub body: VecDeque<Position>,
     pub health: i32,
+    pub shout: Option<String>,
     #[serde(skip)]
     pub actual_length: Option<i32>,
 }
@@ -229,8 +230,6 @@ impl VictorDeterminableGame for Game {
 }
 
 impl YouDeterminableGame for Game {
-    type SnakeIDType = String;
-
     /// determines for a given game if a given snake id is you.
     fn is_you(&self, snake_id: &Self::SnakeIDType) -> bool {
         snake_id == &self.you.id
@@ -270,8 +269,9 @@ impl FoodGettableGame for Game {
     }
 }
 
-impl HealthGettabkeGame for Game {
+impl HealthGettableGame for Game {
     type HealthType = i32;
+    const ZERO: Self::HealthType = 0;
 
     fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType {
         self.board

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -4,9 +4,9 @@ mod simulator;
 
 use crate::compact_representation::{CellBoard, CellNum};
 use crate::types::{
-    FoodGettableGame, HealthGettabkeGame, LengthGettableGame, Move, RandomReasonableMovesGame,
-    SimulableGame, SimulatorInstruments, SnakeIDGettableGame, SnakeIDMap, SnakeMove, Vector,
-    VictorDeterminableGame, YouDeterminableGame,
+    FoodGettableGame, HealthGettabkeGame, LengthGettableGame, Move, PositionGettableGame,
+    RandomReasonableMovesGame, SimulableGame, SimulatorInstruments, SnakeIDGettableGame,
+    SnakeIDMap, SnakeMove, Vector, VictorDeterminableGame, YouDeterminableGame,
 };
 use rand::prelude::IteratorRandom;
 use rand::thread_rng;
@@ -256,9 +256,11 @@ impl LengthGettableGame for Game {
     }
 }
 
-impl FoodGettableGame for Game {
+impl PositionGettableGame for Game {
     type NativePositionType = Position;
+}
 
+impl FoodGettableGame for Game {
     fn get_all_food_as_positions(&self) -> Vec<crate::wire_representation::Position> {
         self.board.food.clone()
     }

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -28,7 +28,7 @@ pub struct BattleSnake {
 }
 
 /// Struct that matches the `position` object from the wire representation
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Position {
     pub x: i32,
     pub y: i32,

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -4,9 +4,9 @@ mod simulator;
 
 use crate::compact_representation::{CellBoard, CellNum};
 use crate::types::{
-    LengthGettableGame, Move, RandomReasonableMovesGame, SimulableGame, SimulatorInstruments,
-    SnakeIDGettableGame, SnakeIDMap, SnakeMove, Vector, VictorDeterminableGame,
-    YouDeterminableGame,
+    FoodGettableGame, HealthGettabkeGame, LengthGettableGame, Move, RandomReasonableMovesGame,
+    SimulableGame, SimulatorInstruments, SnakeIDGettableGame, SnakeIDMap, SnakeMove, Vector,
+    VictorDeterminableGame, YouDeterminableGame,
 };
 use rand::prelude::IteratorRandom;
 use rand::thread_rng;
@@ -253,6 +253,31 @@ impl LengthGettableGame for Game {
             .unwrap()
             .body
             .len()
+    }
+}
+
+impl FoodGettableGame for Game {
+    type NativePositionType = Position;
+
+    fn get_all_food_as_positions(&self) -> Vec<crate::wire_representation::Position> {
+        self.board.food.clone()
+    }
+
+    fn get_all_food_as_native_positions(&self) -> Vec<Self::NativePositionType> {
+        self.get_all_food_as_positions()
+    }
+}
+
+impl HealthGettabkeGame for Game {
+    type HealthType = i32;
+
+    fn get_health(&self, snake_id: &Self::SnakeIDType) -> Self::HealthType {
+        self.board
+            .snakes
+            .iter()
+            .find(|s| &s.id == snake_id)
+            .unwrap()
+            .health
     }
 }
 

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -295,8 +295,8 @@ impl HealthGettableGame for Game {
             .snakes
             .iter()
             .find(|s| &s.id == snake_id)
-            .unwrap()
-            .health
+            .map(|s| s.health)
+            .unwrap_or(Self::ZERO)
     }
 
     fn get_health_i64(&self, snake_id: &Self::SnakeIDType) -> i64 {

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -4,8 +4,9 @@ mod simulator;
 
 use crate::compact_representation::{CellBoard, CellNum};
 use crate::types::{
-    Move, RandomReasonableMovesGame, SimulableGame, SimulatorInstruments, SnakeIDGettableGame,
-    SnakeIDMap, SnakeMove, Vector, VictorDeterminableGame, YouDeterminableGame,
+    LengthGettableGame, Move, RandomReasonableMovesGame, SimulableGame, SimulatorInstruments,
+    SnakeIDGettableGame, SnakeIDMap, SnakeMove, Vector, VictorDeterminableGame,
+    YouDeterminableGame,
 };
 use rand::prelude::IteratorRandom;
 use rand::thread_rng;
@@ -238,6 +239,20 @@ impl YouDeterminableGame for Game {
     /// get the id for you for a given game
     fn you_id(&self) -> &Self::SnakeIDType {
         &self.you.id
+    }
+}
+
+impl LengthGettableGame for Game {
+    type LengthType = usize;
+
+    fn get_length(&self, snake_id: &Self::SnakeIDType) -> Self::LengthType {
+        self.board
+            .snakes
+            .iter()
+            .find(|s| &s.id == snake_id)
+            .unwrap()
+            .body
+            .len()
     }
 }
 

--- a/src/wire_representation/simulator.rs
+++ b/src/wire_representation/simulator.rs
@@ -37,16 +37,16 @@ impl BattleSnakeResult {
     #[allow(dead_code)]
     pub fn body(&self) -> &VecDeque<Position> {
         match self {
-            &BattleSnakeResult::Ok(ref x) => &x.body,
-            &BattleSnakeResult::Dead(_, ref x) => &x.body,
+            BattleSnakeResult::Ok(ref x) => &x.body,
+            BattleSnakeResult::Dead(_, ref x) => &x.body,
         }
     }
 
     #[allow(dead_code)]
     pub fn head(&self) -> Position {
         match self {
-            &BattleSnakeResult::Ok(ref x) => x.head,
-            &BattleSnakeResult::Dead(_, ref x) => x.head,
+            BattleSnakeResult::Ok(ref x) => x.head,
+            BattleSnakeResult::Dead(_, ref x) => x.head,
         }
     }
 }
@@ -146,12 +146,7 @@ impl<'a> Simulator<'a> {
                 .filter(|s| !kill_snakes.contains(&s.id))
                 .collect();
             if kill_snakes.contains(&self.g.you.id)
-                || new_game
-                    .board
-                    .snakes
-                    .iter()
-                    .find(|s| s.id == self.g.you.id)
-                    .is_none()
+                || !new_game.board.snakes.iter().any(|s| s.id == self.g.you.id)
             {
                 new_game.you.health = 0;
             }
@@ -180,7 +175,14 @@ impl<'a> Simulator<'a> {
         if !self.g.board.food.contains(&new_head) {
             new_snake.health -= 1;
             if self.g.board.hazards.contains(&new_head) {
-                new_snake.health -= self.g.game.ruleset.settings.as_ref().map(|o| o.hazard_damage_per_turn).unwrap_or(15);
+                new_snake.health -= self
+                    .g
+                    .game
+                    .ruleset
+                    .settings
+                    .as_ref()
+                    .map(|o| o.hazard_damage_per_turn)
+                    .unwrap_or(15);
             }
         } else {
             let last = *new_snake.body.back().expect("it's nonempty");


### PR DESCRIPTION
This adds some new Traits that are implemented (in most cases) for both the Compact and Wire game type

This includes enough interfaces for all my snakes [https://github.com/coreyja/battlesnake-rs/tree/ca/main/devin-compact-2/battlesnake-rs/src] to operate on JUST the interfaces and not rely on either concrete board type

There are basically NO tests for any of these, so bugs are likely to be hiding somewhere. Also the naming is not very well thought out. Whatever I thought of in the moment is what I went with, and haven't gone back and revised this.

One other interesting change is that I made quite a few traits rely on each other, mostly so they could share the associated types. This allowed me to mix and match the traits and still have consistent objects to work with across the various associated types.

I also ran `clippy` before making many other changes, which is why there are lots of 'unrelated' edits