### PR TITLE
[No Merge] Extract 'Evaluate' from being internal to Simulate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ criterion = "0.3"
 [[bench]]
 name = "start_of_game_compact"
 harness = false
+
+[[bench]]
+name = "evaluate"
+harness = false

--- a/benches/evaluate.rs
+++ b/benches/evaluate.rs
@@ -1,0 +1,80 @@
+use battlesnake_game_types::compact_representation::MoveEvaluatableWithStateGame;
+use battlesnake_game_types::wire_representation::Game as DEGame;
+use battlesnake_game_types::{
+    compact_representation::{CellBoard4Snakes11x11, MoveEvaluatableGame},
+    types::{build_snake_id_map, Move, SnakeId},
+};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+
+fn bench_compact_repr_start_of_game_no_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/start_of_game.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [
+        (SnakeId(0), Move::Up),
+        (SnakeId(1), Move::Up),
+        (SnakeId(2), Move::Up),
+        (SnakeId(3), Move::Up),
+    ];
+    c.bench_function("evaluate compact start of game", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves(&moves))
+    });
+}
+
+fn bench_compact_repr_start_of_game_with_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/start_of_game.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [
+        (SnakeId(0), Move::Up),
+        (SnakeId(1), Move::Up),
+        (SnakeId(2), Move::Up),
+        (SnakeId(3), Move::Up),
+    ];
+    let state = compact.generate_state(moves.iter().map(|(sid, m)| (*sid, vec![*m])).collect_vec());
+
+    c.bench_function("evaluate compact start of game with state", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves_with_state(&moves, &state))
+    });
+}
+
+fn bench_compact_repr_late_stage_no_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/late_stage.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [(SnakeId(0), Move::Up), (SnakeId(1), Move::Up)];
+    c.bench_function("evaluate compact late stage", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves(&moves))
+    });
+}
+
+fn bench_compact_repr_late_stage_with_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/late_stage.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [(SnakeId(0), Move::Up), (SnakeId(1), Move::Up)];
+    let state = compact.generate_state(moves.iter().map(|(sid, m)| (*sid, vec![*m])).collect_vec());
+
+    c.bench_function("evaluate compact late stage with state", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves_with_state(&moves, &state))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_compact_repr_start_of_game_no_state,
+    bench_compact_repr_start_of_game_with_state,
+    bench_compact_repr_late_stage_no_state,
+    bench_compact_repr_late_stage_with_state,
+);
+criterion_main!(benches);

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -1070,12 +1070,23 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SnakeBodyGett
     fn get_snake_body_vec(&self, snake_id: &Self::SnakeIDType) -> Vec<Self::NativePositionType> {
         let mut body = vec![];
         body.reserve(self.get_length(*snake_id).into());
-        let mut cur = Some(self.get_head_as_native_position(snake_id));
+        let head = self.get_head_as_native_position(snake_id);
+
+        let mut cur = Some(self.get_cell(head).get_tail_position(head).unwrap());
 
         while let Some(c) = cur {
             body.push(c);
+            if self.get_cell(c).is_double_stacked_piece() {
+                body.push(c);
+            }
+            if self.get_cell(c).is_triple_stacked_piece() {
+                body.push(c);
+                body.push(c);
+            }
             cur = self.get_cell(c).get_next_index();
         }
+
+        body.reverse();
 
         body
     }

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -1424,7 +1424,7 @@ mod test {
     }
 }
 
-trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGame + Sized {
+pub trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGame + Sized {
     type PreparedState;
 
     fn generate_state(
@@ -1439,7 +1439,7 @@ trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGame +
     ) -> Self;
 }
 
-trait MoveEvaluatableGame: SnakeIDGettableGame + PositionGettableGame + Sized {
+pub trait MoveEvaluatableGame: SnakeIDGettableGame + PositionGettableGame + Sized {
     fn evaluate_moves(&self, moves: &[(Self::SnakeIDType, Move)]) -> Self;
 }
 
@@ -1453,7 +1453,7 @@ impl<T: MoveEvaluatableWithStateGame> MoveEvaluatableGame for T {
     }
 }
 
-struct CellBoardMoveEvalPreparedState<T: CellNum> {
+pub struct CellBoardMoveEvalPreparedState<T: CellNum> {
     new_snake_bodies: Vec<[Option<BattleSnakeResult<T>>; 4]>,
     snake_moves: Vec<Vec<Move>>,
 }

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -613,6 +613,16 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
     pub fn width() -> u8 {
         (BOARD_SIZE as f32).sqrt() as u8
     }
+
+    /// Get all the hazards for this board
+    pub fn get_all_hazards_as_positions(&self) -> Vec<crate::wire_representation::Position> {
+        self.cells
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.is_hazard())
+            .map(|(i, _)| CellIndex(T::from_usize(i)).into_position(Self::width()))
+            .collect()
+    }
 }
 
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SnakeIDGettableGame

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![deny(
-    warnings,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs
+    // warnings,
+    // missing_copy_implementations,
+    // missing_debug_implementations,
+    // missing_docs
 )]
 //! Types for working with [battlesnake](https://docs.battlesnake.com/).
 //! The goal is to provide simulation tooling and fast representations that
@@ -13,19 +13,19 @@
 //! is on the order of about 33% faster for simulation than the wire representation.
 //! ```plain
 //!Gnuplot not found, using plotters backend
-//! compact start of game   time:   [2.7520 us 2.7643 us 2.7774 us]                                   
+//! compact start of game   time:   [2.7520 us 2.7643 us 2.7774 us]
 //!                         change: [-9.0752% -8.5713% -8.0468%] (p = 0.00 < 0.05)
 //!                         Performance has improved.
 //!
-//! vec game start of game  time:   [4.1108 us 4.1303 us 4.1498 us]                                    
+//! vec game start of game  time:   [4.1108 us 4.1303 us 4.1498 us]
 //!                         change: [-12.869% -9.2803% -5.8488%] (p = 0.00 < 0.05)
 //!                         Performance has improved.
 //! Found 1 outliers among 100 measurements (1.00%)
 //!   1 (1.00%) high mild
 //!
-//! compact late stage      time:   [14.098 us 14.152 us 14.209 us]                                
+//! compact late stage      time:   [14.098 us 14.152 us 14.209 us]
 //!
-//! vec late stage          time:   [21.124 us 21.337 us 21.592 us]                            
+//! vec late stage          time:   [21.124 us 21.337 us 21.592 us]
 //! Found 14 outliers among 100 measurements (14.00%)
 //! ```
 


### PR DESCRIPTION
This is really just to have an easy comparison point for my new Eval. That PR is up next, this can probably just be closed once that is no longer open.

Pulled this out so I could bench it alone, and in Simulate to compare