### PR TITLE
Extract and Replace the Move Evaluation Algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ criterion = "0.3"
 [[bench]]
 name = "start_of_game_compact"
 harness = false
+
+[[bench]]
+name = "evaluate"
+harness = false

--- a/benches/evaluate.rs
+++ b/benches/evaluate.rs
@@ -1,0 +1,80 @@
+use battlesnake_game_types::compact_representation::MoveEvaluatableWithStateGame;
+use battlesnake_game_types::wire_representation::Game as DEGame;
+use battlesnake_game_types::{
+    compact_representation::{CellBoard4Snakes11x11, MoveEvaluatableGame},
+    types::{build_snake_id_map, Move, SnakeId},
+};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+
+fn bench_compact_repr_start_of_game_no_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/start_of_game.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [
+        (SnakeId(0), Move::Up),
+        (SnakeId(1), Move::Up),
+        (SnakeId(2), Move::Up),
+        (SnakeId(3), Move::Up),
+    ];
+    c.bench_function("evaluate compact start of game", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves(&moves))
+    });
+}
+
+fn bench_compact_repr_start_of_game_with_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/start_of_game.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [
+        (SnakeId(0), Move::Up),
+        (SnakeId(1), Move::Up),
+        (SnakeId(2), Move::Up),
+        (SnakeId(3), Move::Up),
+    ];
+    let state = compact.generate_state(moves.iter().map(|(sid, m)| (*sid, vec![*m])).collect_vec());
+
+    c.bench_function("evaluate compact start of game with state", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves_with_state(&moves, &state))
+    });
+}
+
+fn bench_compact_repr_late_stage_no_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/late_stage.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [(SnakeId(0), Move::Up), (SnakeId(1), Move::Up)];
+    c.bench_function("evaluate compact late stage", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves(&moves))
+    });
+}
+
+fn bench_compact_repr_late_stage_with_state(c: &mut Criterion) {
+    let game_fixture = include_str!("../fixtures/late_stage.json");
+    let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+    let g = g.expect("the json literal is valid");
+    let snake_id_mapping = build_snake_id_map(&g);
+    let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+    let moves = [(SnakeId(0), Move::Up), (SnakeId(1), Move::Up)];
+    let state = compact.generate_state(moves.iter().map(|(sid, m)| (*sid, vec![*m])).collect_vec());
+
+    c.bench_function("evaluate compact late stage with state", |b| {
+        b.iter(|| black_box(&compact).evaluate_moves_with_state(&moves, &state))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_compact_repr_start_of_game_no_state,
+    bench_compact_repr_start_of_game_with_state,
+    bench_compact_repr_late_stage_no_state,
+    bench_compact_repr_late_stage_with_state,
+);
+criterion_main!(benches);

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -1013,6 +1013,11 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                     // Food is removed naturally by overriding the Cell with the body, which will
                     // happen later
                 }
+
+                // Step 4a: Out of health
+                if new.get_health(*id) == Self::ZERO {
+                    new.kill_and_remove(*id);
+                }
             } else {
                 // Step 4b: Moved out of bounds
                 new.kill_and_remove(*id);
@@ -1022,17 +1027,6 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
         // Step 3: Any new food spawning will be placed in empty squares on the board.
         // This step is ignored because we don't want to guess at food spawn locations as they are
         // random
-
-        for (id, _old_head, _new_head, _old_tail, _new_tail) in new_heads.iter().flatten() {
-            if !new.is_alive(id) {
-                continue;
-            }
-
-            // Step 4a: Out of health
-            if new.get_health(*id) == Self::ZERO {
-                new.kill_and_remove(*id);
-            }
-        }
 
         let mut to_kill = [false; MAX_SNAKES];
 

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -933,6 +933,7 @@ pub enum SinglePlayerMoveResult<T: CellNum> {
         new_tail: CellIndex<T>,
         new_health: u8,
         ate_food: bool,
+        new_length: u16,
     },
     Dead,
 }
@@ -948,6 +949,7 @@ impl<T: CellNum> SinglePlayerMoveResult<T> {
         CellIndex<T>,
         u8,
         bool,
+        u16,
     )> {
         match *self {
             SinglePlayerMoveResult::Alive {
@@ -958,8 +960,9 @@ impl<T: CellNum> SinglePlayerMoveResult<T> {
                 old_tail,
                 new_health,
                 ate_food,
+                new_length,
             } => Some((
-                id, old_head, new_head, old_tail, new_tail, new_health, ate_food,
+                id, old_head, new_head, old_tail, new_tail, new_health, ate_food, new_length,
             )),
             _ => None,
         }
@@ -969,15 +972,6 @@ impl<T: CellNum> SinglePlayerMoveResult<T> {
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatableWithStateGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
-    // type PreparedState = [std::option::Option<(
-    //     SnakeId,                           // id
-    //     CellIndex<T>,                      // old_head
-    //     std::option::Option<CellIndex<T>>, // new_head
-    //     CellIndex<T>,                      // old_tail
-    //     CellIndex<T>,                      // new_tail
-    //     Option<u8>,                        // new_health
-    //     bool,                              // at_food
-    // )>; MAX_SNAKES];
     type PreparedState = [SinglePlayerMoveResult<T>; MAX_SNAKES];
 
     fn generate_state(
@@ -1017,10 +1011,13 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
             }
 
             let ate_food = self.get_cell(new_head).is_food();
+            let mut new_length = self.lengths[id.as_usize()];
 
             if ate_food {
                 new_health = 100;
-            }
+            } else {
+                new_length = new_length.saturating_sub(1);
+            };
 
             if new_health == Self::ZERO {
                 continue;
@@ -1034,6 +1031,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                 old_tail,
                 new_health,
                 ate_food,
+                new_length,
             };
         }
 
@@ -1057,6 +1055,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                     old_tail,
                     new_health,
                     ate_food,
+                    new_length,
                 } => {
                     // Step 1a is delayed and done later. This is to not run into issues with
                     // overriding someone elses tail which would break the representation and make it
@@ -1073,12 +1072,11 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
 
                     // Apply new health
                     new.healths[id.as_usize()] = *new_health;
+                    new.lengths[id.as_usize()] = *new_length;
 
                     // Step 2: Any Battlesnake that has found food will consume it
                     // Reset health to max if ate food
                     if *ate_food {
-                        new.lengths[id.as_usize()] = new.lengths[id.as_usize()].saturating_add(1);
-
                         let new_tail_cell = new.get_cell(*new_tail);
                         new.set_cell_double_stacked(*new_tail, *id, new_tail_cell.idx);
 
@@ -1136,7 +1134,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                 )
             };
 
-            for (loser, _, _, _, _, _, _) in snake_move_info
+            for (loser, _, _, _, _, _, _, _) in snake_move_info
                 .iter()
                 .filter(|x| Some(x.0) != winner.map(|x| x.0))
             {
@@ -1144,7 +1142,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
             }
         }
 
-        for (id, old_head, new_head, _old_tail, new_tail, _, _) in
+        for (id, old_head, new_head, _old_tail, new_tail, _, _, _) in
             new_heads.iter().flat_map(|result| result.to_tuple())
         {
             if to_kill[id.as_usize()] || !new.is_alive(&id) {

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -1070,12 +1070,23 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SnakeBodyGett
     fn get_snake_body_vec(&self, snake_id: &Self::SnakeIDType) -> Vec<Self::NativePositionType> {
         let mut body = vec![];
         body.reserve(self.get_length(*snake_id).into());
-        let mut cur = Some(self.get_head_as_native_position(snake_id));
+        let head = self.get_head_as_native_position(snake_id);
+
+        let mut cur = Some(self.get_cell(head).get_tail_position(head).unwrap());
 
         while let Some(c) = cur {
             body.push(c);
+            if self.get_cell(c).is_double_stacked_piece() {
+                body.push(c);
+            }
+            if self.get_cell(c).is_triple_stacked_piece() {
+                body.push(c);
+                body.push(c);
+            }
             cur = self.get_cell(c).get_next_index();
         }
+
+        body.reverse();
 
         body
     }

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -8,14 +8,11 @@ use crate::types::{
 /// cast from a json represention to a `CellBoard`
 use crate::types::{NeighborDeterminableGame, SnakeBodyGettableGame};
 use crate::wire_representation::Game;
-use fxhash::FxHashSet;
 use itertools::Itertools;
 use rand::prelude::IteratorRandom;
 use rand::thread_rng;
-use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::Display;
-use std::ops::Deref;
 use std::time::Instant;
 
 use crate::{
@@ -176,14 +173,6 @@ impl<T: CellNum> Cell<T> {
         self.idx = CellIndex(T::from_i32(0));
     }
 
-    fn matches_snake_id(&self, sid: SnakeId) -> bool {
-        if self.is_body_segment() {
-            self.id == sid
-        } else {
-            false
-        }
-    }
-
     fn is_stacked(&self) -> bool {
         self.is_double_stacked_piece() || self.is_triple_stacked_piece()
     }
@@ -332,23 +321,6 @@ fn get_snake_id(
         None
     } else {
         Some(*snake_ids.get(&snake.id).unwrap())
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum BattleSnakeResult<T: CellNum> {
-    Alive(Vec<(CellIndex<T>, u8)>),
-    Dead(Vec<(CellIndex<T>, u8)>),
-}
-
-impl<T: CellNum> Deref for BattleSnakeResult<T> {
-    type Target = [(CellIndex<T>, u8)];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            BattleSnakeResult::Alive(positions) => positions,
-            BattleSnakeResult::Dead(positions) => positions,
-        }
     }
 }
 
@@ -528,107 +500,6 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
         let mut old_cell = self.get_cell(cell_index);
         old_cell.set_head(sid, next_id);
         self.cells[cell_index.0.as_usize()] = old_cell;
-    }
-
-    fn forward_simulate(&self, width: u8, sid: SnakeId, mv: Move) -> Option<BattleSnakeResult<T>> {
-        if self.healths[sid.0 as usize] == 0 {
-            return None;
-        }
-        let cell_index = self.heads[sid.0 as usize];
-        let mut alive = true;
-
-        let old_head_cell = self.get_cell(cell_index);
-
-        let old_tail_index = old_head_cell.get_tail_position(cell_index).unwrap();
-        let old_tail_cell = self.get_cell(old_tail_index);
-        let tail_stacked = old_tail_cell.is_stacked();
-
-        let new_head = cell_index.into_position(width).add_vec(mv.to_vector());
-        let new_head_index = CellIndex::new(new_head, width);
-        let head_collides_with_tail = new_head_index == old_tail_index && tail_stacked;
-        if self.off_board(new_head, width) {
-            alive = false;
-        } else if (self.get_cell(new_head_index).matches_snake_id(sid)
-            && new_head_index != old_tail_index)
-            || head_collides_with_tail
-        {
-            return None;
-        }
-
-        let tail_index = old_tail_index;
-
-        let mut new_positions = Vec::with_capacity(self.lengths[sid.0 as usize] as usize + 3);
-        let mut current_index = tail_index;
-        while self.get_cell(current_index).is_body_segment() {
-            if self.cell_is_snake_body_piece(current_index) {
-                let is_tail = current_index == tail_index;
-                current_index = self
-                    .get_cell(current_index)
-                    .get_next_index()
-                    .expect("couldn't get next index from cell");
-                if is_tail && alive && self.get_cell(new_head_index).is_food() {
-                    new_positions.push((current_index, 2));
-                } else {
-                    new_positions.push((current_index, 1));
-                }
-            } else if self.cell_is_double_stacked_piece(current_index) {
-                let is_tail = current_index == tail_index;
-                assert!(is_tail);
-                let next_index = self
-                    .get_cell(current_index)
-                    .get_next_index()
-                    .expect("couldn't get next index from cell");
-                // e.g. [(2,2)] -> [(2,2), (1,2)], because we'll get reversed
-                if is_tail && alive && self.get_cell(new_head_index).is_food() {
-                    new_positions.push((current_index, 2));
-                } else {
-                    new_positions.push((current_index, 1));
-                }
-                new_positions.push((next_index, 1));
-                current_index = next_index
-            } else if self.cell_is_triple_stacked_piece(current_index) {
-                new_positions.push((current_index, 2));
-                break;
-            } else {
-                panic!("wrong body segment type")
-            }
-        }
-        if alive {
-            new_positions.push((new_head_index, 1));
-        }
-
-        if new_positions.is_empty() {
-            let mut yolo_map = [vec![], vec![], vec![], vec![], vec![]];
-            for (index, _) in &new_positions {
-                let key = index.0.as_usize() % yolo_map.len();
-                if yolo_map[key].contains(&index.0) {
-                    alive = false;
-                    break;
-                }
-                yolo_map[key].push(index.0);
-            }
-        } else {
-            let mut set: FxHashSet<T> =
-                HashSet::with_capacity_and_hasher(new_positions.len(), Default::default());
-            for (index, _) in &new_positions {
-                let key = index.0;
-                if set.contains(&key) {
-                    alive = false;
-                    break;
-                }
-                set.insert(key);
-            }
-        }
-
-        //if new_positions.iter().map(|x| x.0).duplicates().count() != 0 {
-        //    alive = false;
-        //}
-        new_positions.reverse();
-        Some(if alive {
-            BattleSnakeResult::Alive(new_positions)
-        } else {
-            BattleSnakeResult::Dead(new_positions)
-        })
     }
 
     /// gets the snake ID at a given index, returns None if the provided index is not a snake cell
@@ -923,24 +794,40 @@ impl<T: SimulatorInstruments, N: CellNum, const BOARD_SIZE: usize, const MAX_SNA
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
+/// This is the pre-captured state for the two-phase move evaluation
+/// For each alive snake we store some things for easy lookups later
+/// For dead snakes we don't need to record anything.
+/// Snakes can 'die' in the process phase, or in the actual evaluate function.
 pub enum SinglePlayerMoveResult<T: CellNum> {
+    /// Represents the given snake is alive after phase 1 of evaluation
     Alive {
+        /// This sid for this snake
         id: SnakeId,
+        /// CellIndex for where the head used to be
         old_head: CellIndex<T>,
+        /// CellIndex where the new head will be
         new_head: CellIndex<T>,
+        /// CellIndex where the tail was previously
         old_tail: CellIndex<T>,
+        /// CellIndex where the tail will be
         new_tail: CellIndex<T>,
+        /// The new health of the snake
         new_health: u8,
+        /// True if the snake ate food
         ate_food: bool,
+        /// The new length of the snake, after moving and potentially eating
         new_length: u16,
     },
+    /// Represents the snake died during phase 1. Cause it ran into a snake (including itself)
+    /// [excluding head to heads] or went out of bounds
     Dead,
 }
 
 impl<T: CellNum> SinglePlayerMoveResult<T> {
+    #[allow(clippy::type_complexity)]
     fn to_tuple(
-        &self,
+        self,
     ) -> Option<(
         SnakeId,
         CellIndex<T>,
@@ -951,7 +838,7 @@ impl<T: CellNum> SinglePlayerMoveResult<T> {
         bool,
         u16,
     )> {
-        match *self {
+        match self {
             SinglePlayerMoveResult::Alive {
                 id,
                 new_head,
@@ -1053,13 +940,13 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
             match result {
                 SinglePlayerMoveResult::Alive {
                     id,
-                    new_head,
                     old_head,
                     new_tail,
                     old_tail,
                     new_health,
                     ate_food,
                     new_length,
+                    ..
                 } => {
                     // Step 1a is delayed and done later. This is to not run into issues with
                     // overriding someone elses tail which would break the representation and make it
@@ -1597,14 +1484,21 @@ mod test {
     }
 }
 
+/// Specialized Trait for Move Evaluation in Simulation
+/// Some steps of eval can be precomputed for each snake move and don't rely on the cartersian
+/// product.
+/// This allows the algorithem to be significantly faster in simulation
 pub trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGame + Sized {
+    /// The type that is prepared ahead of time and passed into each evaluate usage
     type PreparedState;
 
+    /// Prepare the state for each snake move
     fn generate_state(
         &self,
         snake_ids_and_moves: Vec<(Self::SnakeIDType, Vec<crate::types::Move>)>,
     ) -> Self::PreparedState;
 
+    /// Evaluate the given moves with the precomputed state from Self::generate_state
     fn evaluate_moves_with_state(
         &self,
         moves: &[(Self::SnakeIDType, Move)],
@@ -1612,7 +1506,9 @@ pub trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGa
     ) -> Self;
 }
 
+/// Evaluate the given set of moves on the Board and return a new Game for the result
 pub trait MoveEvaluatableGame: SnakeIDGettableGame + PositionGettableGame + Sized {
+    /// Evaluate the given moves on this Board
     fn evaluate_moves(&self, moves: &[(Self::SnakeIDType, Move)]) -> Self;
 }
 
@@ -1624,9 +1520,4 @@ impl<T: MoveEvaluatableWithStateGame> MoveEvaluatableGame for T {
             .collect_vec();
         self.evaluate_moves_with_state(moves, &self.generate_state(simulate_ver))
     }
-}
-
-pub struct CellBoardMoveEvalPreparedState<T: CellNum> {
-    new_snake_bodies: Vec<[Option<BattleSnakeResult<T>>; 4]>,
-    snake_moves: Vec<Vec<Move>>,
 }

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -1424,7 +1424,7 @@ mod test {
     }
 }
 
-trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGame + Sized {
+pub trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGame + Sized {
     type PreparedState;
 
     fn generate_state(
@@ -1439,7 +1439,7 @@ trait MoveEvaluatableWithStateGame: SnakeIDGettableGame + PositionGettableGame +
     ) -> Self;
 }
 
-trait MoveEvaluatableGame: SnakeIDGettableGame + PositionGettableGame + Sized {
+pub trait MoveEvaluatableGame: SnakeIDGettableGame + PositionGettableGame + Sized {
     fn evaluate_moves(&self, moves: &[(Self::SnakeIDType, Move)]) -> Self;
 }
 
@@ -1453,7 +1453,7 @@ impl<T: MoveEvaluatableWithStateGame> MoveEvaluatableGame for T {
     }
 }
 
-struct CellBoardMoveEvalPreparedState<T: CellNum> {
+pub struct CellBoardMoveEvalPreparedState<T: CellNum> {
     new_snake_bodies: Vec<[Option<BattleSnakeResult<T>>; 4]>,
     snake_moves: Vec<Vec<Move>>,
 }

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -363,7 +363,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
 
     fn kill_and_remove(&mut self, sid: SnakeId) {
         let head = self.heads[sid.as_usize()];
-        let mut current_index = Some(self.get_cell(head).get_tail_position(head).unwrap());
+        let mut current_index = self.get_cell(head).get_tail_position(head);
 
         while let Some(i) = current_index {
             current_index = self.get_cell(i).get_next_index();

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -903,7 +903,7 @@ impl<T: SimulatorInstruments, N: CellNum, const BOARD_SIZE: usize, const MAX_SNA
         snake_ids_and_moves: Vec<(Self::SnakeIDType, Vec<crate::types::Move>)>,
     ) -> Vec<(Vec<(Self::SnakeIDType, crate::types::Move)>, Self)> {
         let start = Instant::now();
-        let eval_state = ();
+        let eval_state = self.generate_state(snake_ids_and_moves.clone());
         let ids_and_moves = snake_ids_and_moves
             .into_iter()
             .filter(|(_, moves)| !moves.is_empty())
@@ -926,26 +926,24 @@ impl<T: SimulatorInstruments, N: CellNum, const BOARD_SIZE: usize, const MAX_SNA
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatableWithStateGame
     for CellBoard<T, BOARD_SIZE, MAX_SNAKES>
 {
-    type PreparedState = ();
+    type PreparedState = [std::option::Option<(
+        SnakeId,
+        CellIndex<T>,
+        std::option::Option<CellIndex<T>>,
+        CellIndex<T>,
+        CellIndex<T>,
+    )>; MAX_SNAKES];
 
     fn generate_state(
         &self,
-        _snake_ids_and_moves: Vec<(Self::SnakeIDType, Vec<crate::types::Move>)>,
+        moves: Vec<(Self::SnakeIDType, Vec<crate::types::Move>)>,
     ) -> Self::PreparedState {
-    }
-
-    fn evaluate_moves_with_state(
-        &self,
-        moves: &[(Self::SnakeIDType, Move)],
-        _state: &Self::PreparedState,
-    ) -> Self {
-        let mut new = *self;
-
         let mut new_heads = [None; MAX_SNAKES];
 
         for (id, m) in moves.iter() {
-            let old_head = new.get_head_as_native_position(id);
-            let old_tail = new
+            let m = m.first().unwrap(); // TODO: We need to support multiple moves per snake here eventually
+            let old_head = self.get_head_as_native_position(id);
+            let old_tail = self
                 .get_cell(old_head)
                 .get_tail_position(old_head)
                 .expect("We came from a head so we should have a tail");
@@ -957,7 +955,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                 Some(CellIndex::<T>::new(new_head_position, Self::width()))
             };
 
-            let old_tail_cell = new.get_cell(old_tail);
+            let old_tail_cell = self.get_cell(old_tail);
             let new_tail = if old_tail_cell.is_stacked() {
                 old_tail
             } else {
@@ -966,8 +964,18 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                     .expect("We specificly went to a tail so this shouldn't fail")
             };
 
-            new_heads[id.as_usize()] = Some((id, old_head, new_head, old_tail, new_tail));
+            new_heads[id.as_usize()] = Some((*id, old_head, new_head, old_tail, new_tail));
         }
+
+        new_heads
+    }
+
+    fn evaluate_moves_with_state(
+        &self,
+        moves: &[(Self::SnakeIDType, Move)],
+        new_heads: &Self::PreparedState,
+    ) -> Self {
+        let mut new = *self;
 
         for (id, old_head, new_head, old_tail, new_tail) in new_heads.iter().flatten() {
             // Step 1: Each Battlesnake will have its chosen move applied
@@ -980,10 +988,10 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                 // Remove old tail
                 let old_tail_cell = new.get_cell(*old_tail);
                 if old_tail_cell.is_double_stacked_piece() {
-                    new.set_cell_body_piece(*old_tail, **id, old_tail_cell.idx);
+                    new.set_cell_body_piece(*old_tail, *id, old_tail_cell.idx);
                 } else {
                     new.cell_remove(*old_tail);
-                    new.set_cell_head(*old_head, **id, *new_tail)
+                    new.set_cell_head(*old_head, *id, *new_tail)
                 }
 
                 // Change health
@@ -1000,14 +1008,14 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                     new.lengths[id.as_usize()] = new.lengths[id.as_usize()].saturating_add(1);
 
                     let new_tail_cell = new.get_cell(*new_tail);
-                    new.set_cell_double_stacked(*new_tail, **id, new_tail_cell.idx);
+                    new.set_cell_double_stacked(*new_tail, *id, new_tail_cell.idx);
 
                     // Food is removed naturally by overriding the Cell with the body, which will
                     // happen later
                 }
             } else {
                 // Step 4b: Moved out of bounds
-                new.kill_and_remove(**id);
+                new.kill_and_remove(*id);
             }
         }
 
@@ -1016,13 +1024,13 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
         // random
 
         for (id, _old_head, _new_head, _old_tail, _new_tail) in new_heads.iter().flatten() {
-            if !new.is_alive(*id) {
+            if !new.is_alive(id) {
                 continue;
             }
 
             // Step 4a: Out of health
-            if new.get_health(**id) == Self::ZERO {
-                new.kill_and_remove(**id);
+            if new.get_health(*id) == Self::ZERO {
+                new.kill_and_remove(*id);
             }
         }
 
@@ -1057,7 +1065,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
         let grouped_heads = new_heads
             .iter()
             .flatten()
-            .filter(|info| new.is_alive(info.0))
+            .filter(|info| new.is_alive(&info.0))
             .into_group_map_by(|t| t.2);
         let head_to_head_collistions = grouped_heads
             .iter()
@@ -1067,7 +1075,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
         for (_pos, snake_move_info) in head_to_head_collistions {
             let all_snakes_same_length = snake_move_info
                 .iter()
-                .map(|x| new.get_length(*x.0))
+                .map(|x| new.get_length(x.0))
                 .dedup()
                 .collect_vec()
                 .len()
@@ -1079,7 +1087,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
                 Some(
                     snake_move_info
                         .iter()
-                        .map(|i| (*i, new.get_length(*i.0)))
+                        .map(|i| (*i, new.get_length(i.0)))
                         .max_by_key(|x| x.1)
                         .unwrap()
                         .0,
@@ -1088,28 +1096,28 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
 
             for (loser, _, _, _, _) in snake_move_info
                 .iter()
-                .filter(|x| Some(*x.0) != winner.map(|x| *x.0))
+                .filter(|x| Some(x.0) != winner.map(|x| x.0))
             {
                 to_kill[loser.as_usize()] = true;
             }
         }
 
         for (id, old_head, new_head, _old_tail, new_tail) in new_heads.iter().flatten() {
-            if to_kill[id.as_usize()] || !new.is_alive(*id) {
+            if to_kill[id.as_usize()] || !new.is_alive(id) {
                 continue;
             }
 
             let new_head = new_head.unwrap();
 
             new.heads[id.as_usize()] = new_head;
-            new.set_cell_head(new_head, **id, *new_tail);
+            new.set_cell_head(new_head, *id, *new_tail);
 
             let old_head_cell = self.get_cell(*old_head);
 
             if old_head_cell.is_triple_stacked_piece() {
-                new.set_cell_double_stacked(*old_head, **id, new_head);
+                new.set_cell_double_stacked(*old_head, *id, new_head);
             } else {
-                new.set_cell_body_piece(*old_head, **id, new_head);
+                new.set_cell_body_piece(*old_head, *id, new_head);
             }
         }
 

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -1145,25 +1145,20 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> MoveEvaluatab
         for (id, old_head, new_head, _old_tail, new_tail, _, _, _) in
             new_heads.iter().flat_map(|result| result.to_tuple())
         {
-            if to_kill[id.as_usize()] || !new.is_alive(&id) {
-                continue;
-            }
-
-            new.heads[id.as_usize()] = new_head;
-            new.set_cell_head(new_head, id, new_tail);
-
-            let old_head_cell = self.get_cell(old_head);
-
-            if old_head_cell.is_triple_stacked_piece() {
-                new.set_cell_double_stacked(old_head, id, new_head);
+            if to_kill[id.as_usize()] {
+                // Kill any player killed via collisions
+                new.kill_and_remove(id);
             } else {
-                new.set_cell_body_piece(old_head, id, new_head);
-            }
-        }
+                // Move Head
+                new.heads[id.as_usize()] = new_head;
+                new.set_cell_head(new_head, id, new_tail);
 
-        for (i, kill) in to_kill.iter().enumerate() {
-            if *kill {
-                new.kill_and_remove(SnakeId(i as u8));
+                let old_head_cell = self.get_cell(old_head);
+                if old_head_cell.is_triple_stacked_piece() {
+                    new.set_cell_double_stacked(old_head, id, new_head);
+                } else {
+                    new.set_cell_body_piece(old_head, id, new_head);
+                }
             }
         }
 

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -613,6 +613,16 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
     pub fn width() -> u8 {
         (BOARD_SIZE as f32).sqrt() as u8
     }
+
+    /// Get all the hazards for this board
+    pub fn get_all_hazards_as_positions(&self) -> Vec<crate::wire_representation::Position> {
+        self.cells
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.is_hazard())
+            .map(|(i, _)| CellIndex(T::from_usize(i)).into_position(Self::width()))
+            .collect()
+    }
 }
 
 impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SnakeIDGettableGame

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![deny(
-    // warnings,
-    // missing_copy_implementations,
-    // missing_debug_implementations,
-    // missing_docs
+    warnings,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs
 )]
 //! Types for working with [battlesnake](https://docs.battlesnake.com/).
 //! The goal is to provide simulation tooling and fast representations that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![deny(
-    warnings,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs
+    // warnings,
+    // missing_copy_implementations,
+    // missing_debug_implementations,
+    // missing_docs
 )]
 //! Types for working with [battlesnake](https://docs.battlesnake.com/).
 //! The goal is to provide simulation tooling and fast representations that
@@ -13,19 +13,19 @@
 //! is on the order of about 33% faster for simulation than the wire representation.
 //! ```plain
 //!Gnuplot not found, using plotters backend
-//! compact start of game   time:   [2.7520 us 2.7643 us 2.7774 us]                                   
+//! compact start of game   time:   [2.7520 us 2.7643 us 2.7774 us]
 //!                         change: [-9.0752% -8.5713% -8.0468%] (p = 0.00 < 0.05)
 //!                         Performance has improved.
 //!
-//! vec game start of game  time:   [4.1108 us 4.1303 us 4.1498 us]                                    
+//! vec game start of game  time:   [4.1108 us 4.1303 us 4.1498 us]
 //!                         change: [-12.869% -9.2803% -5.8488%] (p = 0.00 < 0.05)
 //!                         Performance has improved.
 //! Found 1 outliers among 100 measurements (1.00%)
 //!   1 (1.00%) high mild
 //!
-//! compact late stage      time:   [14.098 us 14.152 us 14.209 us]                                
+//! compact late stage      time:   [14.098 us 14.152 us 14.209 us]
 //!
-//! vec late stage          time:   [21.124 us 21.337 us 21.592 us]                            
+//! vec late stage          time:   [21.124 us 21.337 us 21.592 us]
 //! Found 14 outliers among 100 measurements (14.00%)
 //! ```
 


### PR DESCRIPTION
This works off of https://github.com/penelopezone/battlesnake-game-types/pull/3
and replaces that Eval algorithm with a new one.

This is a 'refactor' and doesn't add any new logic besides what was necessary for the algo changes.
It _should_ be comparable in benches to the linked PR up top:  https://github.com/penelopezone/battlesnake-game-types/pull/3

Initially I expected to be able to make it more performant than the original but I wasn't able to quite get that far. It's about comparable speed as the original at the moment.

BUT I do believe the new evaluate behaves more 'correctly' in certain situations. I think the biggest that I noticed is that the current algo doesn't seem to respect the 'two phase' elimination that is implemented in the official Go repo.
In the official implementation snakes are eliminated in two different phases:
- First we eliminate snakes that have died cause of: health or moving out of bounds
- Next we actually make the move for all alive snakes, and remove the ones who 'died' in phase 1. This allows snakes to move into places that snakes were occupying in phase 1 but died during that phase.
- Finally we eliminate snakes who lost by running into other snakes, OR through head to head battles.


I've been working on a Fuzz testing solution for this eval which isn't very pretty but the code can be found here: https://github.com/coreyja/battlesnake-wasm-eval-tester

I've run the new eval against this fuzzer (but only with standard 11x11 and without food and hazards) and haven't found any issues with the new impl yet.