### PR TITLE
Remove some Error Debugging and Add wrapped logic to one place we missed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "battlesnake-game-types"
-version = "0.9.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "fxhash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "battlesnake-game-types"
-version = "0.11.1"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "fxhash",

--- a/src/wrapped_compact_representation/mod.rs
+++ b/src/wrapped_compact_representation/mod.rs
@@ -1110,7 +1110,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> NeighborDeter
             .map(|mv| {
                 let head_pos = pos.into_position(width);
                 let new_head = head_pos.add_vec(mv.to_vector());
-                let ci = self.to_wrapped_cell_index(new_head);
+                let ci = self.as_wrapped_cell_index(new_head);
 
                 debug_assert!(!self.off_board(ci.into_position(width)));
 

--- a/src/wrapped_compact_representation/mod.rs
+++ b/src/wrapped_compact_representation/mod.rs
@@ -1112,7 +1112,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> NeighborDeter
                 let new_head = head_pos.add_vec(mv.to_vector());
                 let ci = self.to_wrapped_cell_index(new_head);
 
-                debug_assert!(!self.off_board(ci.into_position(width)), "{:?}", new_head);
+                debug_assert!(!self.off_board(ci.into_position(width)));
 
                 (mv, new_head, ci)
             })

--- a/src/wrapped_compact_representation/mod.rs
+++ b/src/wrapped_compact_representation/mod.rs
@@ -1110,8 +1110,9 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> NeighborDeter
             .map(|mv| {
                 let head_pos = pos.into_position(width);
                 let new_head = head_pos.add_vec(mv.to_vector());
-                let ci = CellIndex::new(new_head, width);
-                debug_assert!(!self.off_board(new_head));
+                let ci = self.to_wrapped_cell_index(new_head);
+
+                debug_assert!(!self.off_board(ci.into_position(width)), "{:?}", new_head);
 
                 (mv, new_head, ci)
             })


### PR DESCRIPTION
Got this all integrated with Hobbs locally and they are working!

Removed some of the error debugging that we left in.

We also missed this one spot where we needed to use the `to_wrapped_cell_index` method, but there was a `debug_assert` there which made finding the issue really easy! 🎉 

I'll deploy Hobbs of my branch, so no rush on a merge! Just FYI