### PR TITLE
Add new Hazard Map Settings to Wire Representation

### DIFF
--- a/fixtures/empty_str_hazard.json
+++ b/fixtures/empty_str_hazard.json
@@ -1,0 +1,129 @@
+{
+    "game": {
+        "id": "9c5dcf09-6583-4217-a438-c09d69fdcb32",
+        "ruleset": {
+            "name": "standard",
+            "version": "v1.0.28",
+            "settings": {
+                "foodSpawnChance": 15,
+                "minimumFood": 1,
+                "hazardDamagePerTurn": 14,
+                "hazardMap": "",
+                "hazardMapAuthor": "",
+                "royale": {
+                    "shrinkEveryNTurns": 0
+                },
+                "squad": {
+                    "allowBodyCollisions": false,
+                    "sharedElimination": false,
+                    "sharedHealth": false,
+                    "sharedLength": false
+                }
+            }
+        },
+        "timeout": 500,
+        "source": "custom"
+    },
+    "turn": 12,
+    "board": {
+        "height": 11,
+        "width": 11,
+        "snakes": [
+            {
+                "id": "gs_34Hp9mHjMfPQ6MvGFBSFMRTQ",
+                "name": "Local",
+                "latency": "406",
+                "health": 100,
+                "body": [
+                    {
+                        "x": 7,
+                        "y": 7
+                    },
+                    {
+                        "x": 6,
+                        "y": 7
+                    },
+                    {
+                        "x": 5,
+                        "y": 7
+                    },
+                    {
+                        "x": 5,
+                        "y": 6
+                    },
+                    {
+                        "x": 5,
+                        "y": 6
+                    }
+                ],
+                "head": {
+                    "x": 7,
+                    "y": 7
+                },
+                "length": 5,
+                "shout": "",
+                "squad": "",
+                "customizations": {
+                    "color": "#da8a1a",
+                    "head": "trans-rights-scarf",
+                    "tail": "flame"
+                }
+            }
+        ],
+        "food": [
+            {
+                "x": 2,
+                "y": 10
+            },
+            {
+                "x": 0,
+                "y": 0
+            },
+            {
+                "x": 9,
+                "y": 2
+            }
+        ],
+        "hazards": []
+    },
+    "you": {
+        "id": "gs_34Hp9mHjMfPQ6MvGFBSFMRTQ",
+        "name": "Local",
+        "latency": "406",
+        "health": 100,
+        "body": [
+            {
+                "x": 7,
+                "y": 7
+            },
+            {
+                "x": 6,
+                "y": 7
+            },
+            {
+                "x": 5,
+                "y": 7
+            },
+            {
+                "x": 5,
+                "y": 6
+            },
+            {
+                "x": 5,
+                "y": 6
+            }
+        ],
+        "head": {
+            "x": 7,
+            "y": 7
+        },
+        "length": 5,
+        "shout": "",
+        "squad": "",
+        "customizations": {
+            "color": "#da8a1a",
+            "head": "trans-rights-scarf",
+            "tail": "flame"
+        }
+    }
+}

--- a/fixtures/hazard_map_settings.json
+++ b/fixtures/hazard_map_settings.json
@@ -1,0 +1,166 @@
+{
+    "game": {
+        "id": "f0a48b4f-f677-4779-a5f6-a84c6317fcef",
+        "ruleset": {
+            "name": "standard",
+            "version": "v1.0.28",
+            "settings": {
+                "foodSpawnChance": 15,
+                "minimumFood": 1,
+                "hazardDamagePerTurn": 14,
+                "hazardMap": "hz_spiral",
+                "hazardMapAuthor": "altersaddle",
+                "royale": {
+                    "shrinkEveryNTurns": 0
+                },
+                "squad": {
+                    "allowBodyCollisions": false,
+                    "sharedElimination": false,
+                    "sharedHealth": false,
+                    "sharedLength": false
+                }
+            }
+        },
+        "timeout": 500,
+        "source": "custom"
+    },
+    "turn": 11,
+    "board": {
+        "height": 11,
+        "width": 11,
+        "snakes": [
+            {
+                "id": "gs_hTFpCXxSDPKPGCf9bBmPdVYT",
+                "name": "Local",
+                "latency": "406",
+                "health": 77,
+                "body": [
+                    {
+                        "x": 5,
+                        "y": 6
+                    },
+                    {
+                        "x": 4,
+                        "y": 6
+                    },
+                    {
+                        "x": 4,
+                        "y": 5
+                    },
+                    {
+                        "x": 4,
+                        "y": 4
+                    }
+                ],
+                "head": {
+                    "x": 5,
+                    "y": 6
+                },
+                "length": 4,
+                "shout": "",
+                "squad": "",
+                "customizations": {
+                    "color": "#da8a1a",
+                    "head": "trans-rights-scarf",
+                    "tail": "flame"
+                }
+            },
+            {
+                "id": "gs_PbRCvpGRwcHb79dqQTF7tw4W",
+                "name": "Local",
+                "latency": "405",
+                "health": 91,
+                "body": [
+                    {
+                        "x": 5,
+                        "y": 4
+                    },
+                    {
+                        "x": 6,
+                        "y": 4
+                    },
+                    {
+                        "x": 6,
+                        "y": 5
+                    },
+                    {
+                        "x": 6,
+                        "y": 6
+                    }
+                ],
+                "head": {
+                    "x": 5,
+                    "y": 4
+                },
+                "length": 4,
+                "shout": "",
+                "squad": "",
+                "customizations": {
+                    "color": "#da8a1a",
+                    "head": "trans-rights-scarf",
+                    "tail": "flame"
+                }
+            }
+        ],
+        "food": [
+            {
+                "x": 5,
+                "y": 5
+            },
+            {
+                "x": 8,
+                "y": 9
+            }
+        ],
+        "hazards": [
+            {
+                "x": 5,
+                "y": 5
+            },
+            {
+                "x": 5,
+                "y": 6
+            },
+            {
+                "x": 6,
+                "y": 6
+            }
+        ]
+    },
+    "you": {
+        "id": "gs_hTFpCXxSDPKPGCf9bBmPdVYT",
+        "name": "Local",
+        "latency": "406",
+        "health": 77,
+        "body": [
+            {
+                "x": 5,
+                "y": 6
+            },
+            {
+                "x": 4,
+                "y": 6
+            },
+            {
+                "x": 4,
+                "y": 5
+            },
+            {
+                "x": 4,
+                "y": 4
+            }
+        ],
+        "head": {
+            "x": 5,
+            "y": 6
+        },
+        "length": 4,
+        "shout": "",
+        "squad": "",
+        "customizations": {
+            "color": "#da8a1a",
+            "head": "trans-rights-scarf",
+            "tail": "flame"
+        }
+    }
+}

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -127,7 +127,12 @@ pub struct Ruleset {
     pub settings: Option<Settings>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+fn non_empty_str<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Option<String>, D::Error> {
+    let o: Option<String> = Option::deserialize(d)?;
+    Ok(o.filter(|s| !s.is_empty()))
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Settings {
     #[serde(rename = "foodSpawnChance")]
     pub food_spawn_chance: i32,
@@ -135,6 +140,14 @@ pub struct Settings {
     pub minimum_food: i32,
     #[serde(rename = "hazardDamagePerTurn")]
     pub hazard_damage_per_turn: i32,
+    #[serde(default, rename = "hazardMap", deserialize_with = "non_empty_str")]
+    pub hazard_map: Option<String>,
+    #[serde(
+        default,
+        rename = "hazardMapAuthor",
+        deserialize_with = "non_empty_str"
+    )]
+    pub hazard_map_author: Option<String>,
     pub royale: Option<RoyaleSettings>,
 }
 
@@ -462,6 +475,7 @@ impl HazardQueryableGame for Game {
         self.game
             .ruleset
             .settings
+            .as_ref()
             .map(|settings| settings.hazard_damage_per_turn)
             .unwrap_or(15) as u8
     }
@@ -485,6 +499,47 @@ mod tests {
         let game_fixture = include_str!("../../fixtures/4_snake_game.json");
         let g: Result<Game, _> = serde_json::from_slice(game_fixture.as_bytes());
         g.expect("the json literal is valid")
+    }
+
+    #[test]
+    fn test_hazard_deserialization() {
+        let empty_string_hazard = include_str!("../../fixtures/empty_str_hazard.json");
+        let empty_string_hazard: Game =
+            serde_json::from_str(empty_string_hazard).expect("the json literal is valid");
+
+        assert_eq!(
+            None,
+            empty_string_hazard
+                .game
+                .ruleset
+                .settings
+                .unwrap()
+                .hazard_map
+        );
+
+        let with_hazard_settings = include_str!("../../fixtures/hazard_map_settings.json");
+        let with_hazard_settings: Game =
+            serde_json::from_str(with_hazard_settings).expect("the json literal is valid");
+
+        assert_eq!(
+            Some("hz_spiral".to_string()),
+            with_hazard_settings
+                .game
+                .ruleset
+                .settings
+                .as_ref()
+                .unwrap()
+                .hazard_map
+        );
+        assert_eq!(
+            Some("altersaddle".to_string()),
+            with_hazard_settings
+                .game
+                .ruleset
+                .settings
+                .unwrap()
+                .hazard_map_author
+        );
     }
 
     #[test]


### PR DESCRIPTION
**This is technically a breaking change, since I dropped a `Copy`
implementation**

This adds the new `hazard_map` and `hazard_map_author` attributes that
come back in the ruleset settings now.

The responses I am currently getting back from the Battlesnake API has
an `""` empty string for these in non-hazard game modes. I decided that
would make more sense to remap to `None` here.

I also decided to make `None` the default value, so that old fixtures
continue to valid

Added a few fixtures to test the new parsing