### PR TITLE
Pea Eater Benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,9 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-flame",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -476,6 +479,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +566,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
@@ -605,11 +630,11 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -817,6 +842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,13 +892,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -911,6 +945,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,22 +964,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
 name = "uuid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,38 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,12 +52,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "battlesnake-game-types"
 version = "0.16.0"
 dependencies = [
  "criterion",
  "fxhash",
  "itertools",
+ "pprof",
  "rand",
  "serde",
  "serde_json",
@@ -56,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
+name = "bytemuck"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +123,12 @@ checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -191,10 +251,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fxhash"
@@ -217,10 +307,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -229,6 +331,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "inferno"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3b820618e1737bba20ec69b6fcd6efb25cfed922669353817e2f24c86bdc10"
+dependencies = [
+ "ahash",
+ "atty",
+ "indexmap",
+ "itoa 1.0.4",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -248,9 +387,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -274,6 +413,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,9 +433,18 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -295,6 +453,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
+dependencies = [
+ "arrayvec",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -317,10 +505,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "plotters"
@@ -351,6 +577,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pprof"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6472bfed9475542ac46c518734a8d06d71b0f6cb2c17f904aa301711a57786f"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +610,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -430,6 +686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +714,30 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3603b7d71ca82644f79b5a06d1220e9a58ede60bd32255f698cb1af8838b8db3"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -522,9 +811,49 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.4",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "symbolic-common"
+version = "9.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "800963ba330b09a2ae4a4f7c6392b81fbc2784099a98c1eac68c3437aa9382b2"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "9.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b940a1fdbc72bb3369e38714efe6cd332dbbe46d093cf03d668b9ac390d1ad0"
+dependencies = [
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]
@@ -539,12 +868,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -568,6 +931,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "uuid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -680,3 +1055,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,13 @@ rand =  {version = "0.8.4", features = ["small_rng"] }
 itertools = "0.10.1"
 fxhash = "0.2.1"
 serde_json = "1.0"
+tracing = { version = "0.1.37" }
+tracing-flame = "0.2.0"
 
 [dev-dependencies]
 criterion = "0.3"
 pprof = { version = "0.10", default-features=false, features = ["flamegraph", "frame-pointer"] }
+tracing-subscriber = "0.3.16"
 
 [[bench]]
 name = "start_of_game_compact"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ criterion = "0.3"
 [[bench]]
 name = "start_of_game_compact"
 harness = false
+
+[[bench]]
+name = "pea_eater"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"
+pprof = { version = "0.10", default-features=false, features = ["flamegraph", "frame-pointer"] }
 
 [[bench]]
 name = "start_of_game_compact"

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -6,14 +6,10 @@ use std::{
 use battlesnake_game_types::{
     compact_representation::StandardCellBoard4Snakes11x11,
     types::{
-        HealthGettableGame, RandomReasonableMovesGame, SimulableGame, SimulatorInstruments,
-        SnakeId, VictorDeterminableGame,
+        RandomReasonableMovesGame, SimulableGame, SimulatorInstruments, VictorDeterminableGame,
     },
 };
-use rand::{
-    rngs::{SmallRng, ThreadRng},
-    thread_rng, Rng, SeedableRng,
-};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 #[derive(Debug)]
 struct Instruments {}

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -6,7 +6,8 @@ use std::{
 use battlesnake_game_types::{
     compact_representation::StandardCellBoard4Snakes11x11,
     types::{
-        RandomReasonableMovesGame, SimulableGame, SimulatorInstruments, VictorDeterminableGame,
+        RandomReasonableMovesGame, SimulableGame, SimulatorInstruments, StandardFoodPlaceableGame,
+        VictorDeterminableGame,
     },
 };
 use rand::{rngs::SmallRng, Rng, SeedableRng};
@@ -39,6 +40,8 @@ fn run_from_fixture_till_end(
             .unwrap()
             .1;
         game = new_game;
+
+        game.place_food(rng);
 
         iterations += 1;
     }

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -10,7 +10,10 @@ use battlesnake_game_types::{
         SnakeId, VictorDeterminableGame,
     },
 };
-use rand::{rngs::ThreadRng, thread_rng};
+use rand::{
+    rngs::{SmallRng, ThreadRng},
+    thread_rng, Rng, SeedableRng,
+};
 
 #[derive(Debug)]
 struct Instruments {}
@@ -20,7 +23,7 @@ impl SimulatorInstruments for Instruments {
 }
 
 fn run_from_fixture_till_end(
-    rng: &mut ThreadRng,
+    rng: &mut impl Rng,
     instrument: Instruments,
     initial_game: StandardCellBoard4Snakes11x11,
 ) -> u64 {
@@ -64,7 +67,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut rng = thread_rng();
+    let mut rng = SmallRng::from_entropy();
     let mut total_iterations = 0;
     let mut game_lengths = Vec::new();
 

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -1,0 +1,46 @@
+use battlesnake_game_types::types::{
+    HealthGettableGame, RandomReasonableMovesGame, SimulableGame, SimulatorInstruments, SnakeId,
+    VictorDeterminableGame,
+};
+use rand::{rngs::ThreadRng, thread_rng};
+
+#[derive(Debug)]
+struct Instruments {}
+
+impl SimulatorInstruments for Instruments {
+    fn observe_simulation(&self, _: std::time::Duration) {}
+}
+
+fn run_from_fixture_till_end(rng: &mut ThreadRng, instrument: Instruments) {
+    let fixture_string = include_str!("../fixtures/e80b70e7-a916-40ca-82d2-ad76e074efe1_0.json");
+    let wire =
+        serde_json::from_str::<battlesnake_game_types::wire_representation::Game>(fixture_string)
+            .unwrap();
+    let id_map = battlesnake_game_types::types::build_snake_id_map(&wire);
+    let initial_game = battlesnake_game_types::compact_representation::StandardCellBoard4Snakes11x11::convert_from_game(wire, &id_map).unwrap();
+
+    let mut game = initial_game;
+
+    while !game.is_over() {
+        let next_move = game
+            .random_reasonable_move_for_each_snake(rng)
+            .map(|(id, m)| (id, [m]));
+
+        let new_game = game
+            .simulate_with_moves(&instrument, next_move)
+            .next()
+            .unwrap()
+            .1;
+        game = new_game;
+
+        dbg!(game.get_health(&SnakeId(0)));
+    }
+}
+fn main() {
+    let instrument = Instruments {};
+    let mut rng = thread_rng();
+
+    run_from_fixture_till_end(&mut rng, instrument);
+
+    println!("Hello, world!");
+}

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -28,7 +28,6 @@ fn run_from_fixture_till_end(
 
     let mut game = initial_game;
 
-    // TODO: Add Food Spawing here somewhere
     while !game.is_over() {
         let next_move = game
             .random_reasonable_move_for_each_snake(rng)

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs::File,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use battlesnake_game_types::{
     compact_representation::StandardCellBoard4Snakes11x11,
@@ -12,7 +9,7 @@ use battlesnake_game_types::{
 };
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use tracing_flame::FlameLayer;
-use tracing_subscriber::{prelude::*, fmt::Layer, Registry};
+use tracing_subscriber::{fmt::Layer, prelude::*, Registry};
 
 #[derive(Debug)]
 struct Instruments {}

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -60,9 +60,15 @@ fn main() {
 
     let fmt_layer = Layer::default();
 
-    let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
-
-    let subscriber = Registry::default().with(fmt_layer).with(flame_layer);
+    let flame_layer: Option<_> = if std::env::var("TRACING_FOLDED").is_ok() {
+        let fl = FlameLayer::with_file("./tracing.folded").unwrap();
+        Some(fl)
+    } else {
+        None
+    };
+    let subscriber = Registry::default()
+        .with(fmt_layer)
+        .with(flame_layer.map(|x| x.0));
 
     tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
 

--- a/fixtures/e80b70e7-a916-40ca-82d2-ad76e074efe1_0.json
+++ b/fixtures/e80b70e7-a916-40ca-82d2-ad76e074efe1_0.json
@@ -1,0 +1,114 @@
+{
+  "you": {
+    "id": "gs_9VWrMjTwtvp9RqF4qf67Jmbc",
+    "name": "Hovering Hobbs",
+    "head": {
+      "x": 1,
+      "y": 1
+    },
+    "body": [
+      {
+        "x": 1,
+        "y": 1
+      },
+      {
+        "x": 1,
+        "y": 1
+      },
+      {
+        "x": 1,
+        "y": 1
+      }
+    ],
+    "health": 100,
+    "shout": ""
+  },
+  "board": {
+    "height": 11,
+    "width": 11,
+    "food": [
+      {
+        "x": 0,
+        "y": 2
+      },
+      {
+        "x": 10,
+        "y": 2
+      },
+      {
+        "x": 5,
+        "y": 5
+      }
+    ],
+    "snakes": [
+      {
+        "id": "gs_9VWrMjTwtvp9RqF4qf67Jmbc",
+        "name": "Hovering Hobbs",
+        "head": {
+          "x": 1,
+          "y": 1
+        },
+        "body": [
+          {
+            "x": 1,
+            "y": 1
+          },
+          {
+            "x": 1,
+            "y": 1
+          },
+          {
+            "x": 1,
+            "y": 1
+          }
+        ],
+        "health": 100,
+        "shout": ""
+      },
+      {
+        "id": "gs_84gHytVR4CRrBhpRyQqhTy3S",
+        "name": "TBD MCTS",
+        "head": {
+          "x": 9,
+          "y": 1
+        },
+        "body": [
+          {
+            "x": 9,
+            "y": 1
+          },
+          {
+            "x": 9,
+            "y": 1
+          },
+          {
+            "x": 9,
+            "y": 1
+          }
+        ],
+        "health": 100,
+        "shout": ""
+      }
+    ],
+    "hazards": []
+  },
+  "turn": 0,
+  "game": {
+    "id": "e80b70e7-a916-40ca-82d2-ad76e074efe1",
+    "ruleset": {
+      "name": "standard",
+      "version": "No version in frames",
+      "settings": {
+        "foodSpawnChance": 15,
+        "minimumFood": 1,
+        "hazardDamagePerTurn": 14,
+        "hazardMap": null,
+        "hazardMapAuthor": null,
+        "royale": null
+      }
+    },
+    "timeout": 500,
+    "map": "standard",
+    "source": "custom"
+  }
+}

--- a/src/compact_representation/core/cell_board/eval.rs
+++ b/src/compact_representation/core/cell_board/eval.rs
@@ -1,6 +1,7 @@
 use std::borrow::Borrow;
 
 use itertools::Itertools;
+use tracing::instrument;
 
 use crate::{
     compact_representation::{core::dimensions::Dimensions, CellNum},
@@ -171,6 +172,7 @@ impl<T: CellNum, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize
         new_heads
     }
 
+    #[instrument(skip_all)]
     pub fn evaluate_moves_with_state<'a>(
         &self,
         moves: impl Iterator<Item = &'a (SnakeId, crate::types::Move)>,

--- a/src/compact_representation/core/cell_board/mod.rs
+++ b/src/compact_representation/core/cell_board/mod.rs
@@ -429,16 +429,19 @@ impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
         self.get_cell(cell_idx).is_body()
     }
 
-    /// determins if this cell is a single stacked snake tail
-    pub(crate) fn cell_is_single_tail(&self, cell_idx: CellIndex<T>) -> bool {
+    pub fn cell_is_single_tail(&self, cell_idx: CellIndex<T>) -> bool {
         let cell = self.get_cell(cell_idx);
-        let snake_id = cell.get_snake_id();
+        if !cell.is_snake_body_piece()
+            || cell.is_double_stacked_piece()
+            || cell.is_triple_stacked_piece()
+        {
+            return false;
+        }
 
-        if let Some(sid) = snake_id {
-            let head_idx = self.get_head_as_native_position(&sid);
-            let tail = self.get_cell(head_idx).get_tail_position(head_idx);
+        if let Some(sid) = cell.get_snake_id() {
+            let head = self.heads[sid.0 as usize];
 
-            Some(cell_idx) == tail
+            self.get_cell(head).get_tail_position(head) == Some(cell_idx)
         } else {
             false
         }

--- a/src/compact_representation/core/cell_board/mod.rs
+++ b/src/compact_representation/core/cell_board/mod.rs
@@ -3,10 +3,15 @@ use std::error::Error;
 use std::slice::Iter;
 
 use itertools::Itertools;
+use rand::seq::IteratorRandom;
 
+use crate::types::EmptyCellGettableGame;
+use crate::types::FoodGettableGame;
+use crate::types::HazardQueryableGame;
 use crate::types::HeadGettableGame;
 use crate::types::SnakeIDMap;
 use crate::types::SnakeId;
+use crate::types::StandardFoodPlaceableGame;
 use crate::wire_representation::Game;
 use crate::wire_representation::Position;
 
@@ -443,6 +448,50 @@ impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
     /// determin the width of the CellBoard
     pub fn width() -> u8 {
         (BOARD_SIZE as f32).sqrt() as u8
+    }
+}
+
+impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize> EmptyCellGettableGame
+    for CellBoard<T, D, BOARD_SIZE, MAX_SNAKES>
+{
+    fn get_empty_cells(&self) -> Box<dyn Iterator<Item = Self::NativePositionType> + '_> {
+        Box::new(
+            self.cells
+                .iter()
+                .enumerate()
+                .filter(|(_, cell)| cell.is_empty())
+                .map(|(idx, _)| CellIndex::from_usize(idx)),
+        )
+    }
+}
+
+impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
+    StandardFoodPlaceableGame for CellBoard<T, D, BOARD_SIZE, MAX_SNAKES>
+{
+    fn place_food(&mut self, rng: &mut impl rand::Rng) {
+        // TODO: Get these constants from the game
+        let min_food = 1;
+        let food_spawn_chance = 0.15;
+
+        let current_food_count = self.get_all_food_as_native_positions().len();
+
+        let food_to_add = if current_food_count < min_food {
+            min_food - current_food_count
+        } else if rng.gen_bool(food_spawn_chance) {
+            1
+        } else {
+            0
+        };
+
+        if food_to_add == 0 {
+            return;
+        }
+
+        let empty = self.get_empty_cells();
+        let random = empty.choose_multiple(rng, food_to_add);
+        for pos in random {
+            self.cells[pos.0.as_usize()].set_food();
+        }
     }
 }
 

--- a/src/compact_representation/core/cell_board/mod.rs
+++ b/src/compact_representation/core/cell_board/mod.rs
@@ -6,7 +6,6 @@ use itertools::Itertools;
 use rand::seq::IteratorRandom;
 
 use crate::types::EmptyCellGettableGame;
-use crate::types::FoodGettableGame;
 use crate::types::HazardQueryableGame;
 use crate::types::HeadGettableGame;
 use crate::types::SnakeIDMap;
@@ -473,10 +472,10 @@ impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
         let min_food = 1;
         let food_spawn_chance = 0.15;
 
-        let current_food_count = self.get_all_food_as_native_positions().len();
-
-        let food_to_add = if current_food_count < min_food {
-            min_food - current_food_count
+        // This is an optimization when min_food is 1. We know we don't need to spawn food if there if any of the board
+        // so we can short circuit on the first food we find
+        let food_to_add = if !self.cells.iter().any(|c| c.is_food()) {
+            min_food
         } else if rng.gen_bool(food_spawn_chance) {
             1
         } else {

--- a/src/compact_representation/core/cell_board/mod.rs
+++ b/src/compact_representation/core/cell_board/mod.rs
@@ -6,8 +6,6 @@ use itertools::Itertools;
 use rand::seq::IteratorRandom;
 
 use crate::types::EmptyCellGettableGame;
-use crate::types::HazardQueryableGame;
-use crate::types::HeadGettableGame;
 use crate::types::SnakeIDMap;
 use crate::types::SnakeId;
 use crate::types::StandardFoodPlaceableGame;
@@ -479,10 +477,8 @@ impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
         // so we can short circuit on the first food we find
         let food_to_add = if !self.cells.iter().any(|c| c.is_food()) {
             min_food
-        } else if rng.gen_bool(food_spawn_chance) {
-            1
         } else {
-            0
+            usize::from(rng.gen_bool(food_spawn_chance))
         };
 
         if food_to_add == 0 {

--- a/src/compact_representation/core/impl_common.rs
+++ b/src/compact_representation/core/impl_common.rs
@@ -214,5 +214,21 @@ macro_rules! impl_common_board_traits {
             MaxSnakes<MAX_SNAKES> for $type<T, D, BOARD_SIZE, MAX_SNAKES>
         {
         }
+
+        impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
+            EmptyCellGettableGame for $type<T, D, BOARD_SIZE, MAX_SNAKES>
+        {
+            fn get_empty_cells(&self) -> Box<dyn Iterator<Item = Self::NativePositionType> + '_> {
+                self.embedded.get_empty_cells()
+            }
+        }
+
+        impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
+            StandardFoodPlaceableGame for $type<T, D, BOARD_SIZE, MAX_SNAKES>
+        {
+            fn place_food(&mut self, rng: &mut impl rand::Rng) {
+                self.embedded.place_food(rng)
+            }
+        }
     };
 }

--- a/src/compact_representation/core/simulate.rs
+++ b/src/compact_representation/core/simulate.rs
@@ -1,11 +1,13 @@
 use std::{borrow::Borrow, time::Instant};
 
 use itertools::Itertools;
+use tracing::instrument;
 
 use crate::types::{Action, Move, SimulatorInstruments, SnakeId, N_MOVES};
 
 use super::{cell_board::EvaluateMode, dimensions::Dimensions, CellBoard, CellNum};
 
+#[instrument(skip_all)]
 pub fn simulate_with_moves<
     'a,
     S,

--- a/src/compact_representation/standard/mod.rs
+++ b/src/compact_representation/standard/mod.rs
@@ -12,6 +12,7 @@ use rand::Rng;
 use std::borrow::Borrow;
 use std::error::Error;
 use std::fmt::Display;
+use tracing::instrument;
 
 use crate::{
     types::{Move, SimulableGame, SimulatorInstruments},
@@ -133,6 +134,7 @@ impl<
     > SimulableGame<T, MAX_SNAKES> for CellBoard<N, D, BOARD_SIZE, MAX_SNAKES>
 {
     #[allow(clippy::type_complexity)]
+    #[instrument(skip_all)]
     fn simulate_with_moves<S>(
         &self,
         instruments: &T,

--- a/src/compact_representation/standard/mod.rs
+++ b/src/compact_representation/standard/mod.rs
@@ -69,6 +69,11 @@ impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
             || new_head.y < 0
             || new_head.y >= self.embedded.get_actual_height() as i32
     }
+
+    /// Return an iterator over all the empty cells on the board
+    pub fn get_all_empty(&self) -> impl Iterator<Item = CellIndex<T>> + '_ {
+        self.embedded.get_empty_cells()
+    }
 }
 
 impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>

--- a/src/types.rs
+++ b/src/types.rs
@@ -458,6 +458,24 @@ pub trait SnakeBodyGettableGame: PositionGettableGame + SnakeIDGettableGame {
 /// A marker trait that can be used to specify the number of snakes this board can support
 pub trait MaxSnakes<const MAX_SNAKES: usize> {}
 
+/// A game where we can get all the empty cells
+pub trait EmptyCellGettableGame: PositionGettableGame {
+    /// get the empty cells on the board
+    fn get_empty_cells(&self) -> Box<dyn Iterator<Item = Self::NativePositionType> + '_>;
+}
+
+/// A game that can place food following the standard rules
+///
+/// - If the number of Food on the board is less than the minimum spawn enough food to reach the miniumum.
+/// - Otherwise there is a 15% chance of spawning a single food
+/// - Otherwise no food spawns
+///
+/// - When food spawns place it randomly on the empty cells of the board
+pub trait StandardFoodPlaceableGame {
+    /// place food on the board according to the standard rules
+    fn place_food(&mut self, rng: &mut impl Rng);
+}
+
 #[cfg(test)]
 mod test {
 


### PR DESCRIPTION
This adds a new benchmark called "Pea Eater" that can be used to compare the simulation speed to Pea Eater in Discord!

I'm getting a bit lost in my git branches... This one is rebased on `main` nicely, and ready to merge!

BUTT I have one from a few months ago that is MUCH faster in this benchmark. Will want to compare and figure out why, but I think I want to land this first so that `main` is nice and stable. And we can iterate from there nicely.

Will confirm this doesn't make other benches slower, and then merge it in
