### PR TITLE
Support Stacked Hazards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "battlesnake-game-types"
 version = "0.17.0"
 authors = ["Penelope Phippen <penelope@hey.com>", "Corey Alexander <coreyja@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "game types for play.battlesnake.com"
 license = "Apache-2.0"
 repository = "https://github.com/penelopezone/battlesnake-game-types"

--- a/benches/pea_eater.rs
+++ b/benches/pea_eater.rs
@@ -86,10 +86,10 @@ fn main() {
 
     let average_game_length = game_lengths.iter().sum::<u64>() as f64 / game_lengths.len() as f64;
 
-    println!("Total iterations: {}", total_iterations);
-    println!("Total time: {:?}", total_time);
-    println!("Iterations per second: {}", iterations_per_second);
-    println!("Average game length: {}", average_game_length);
+    println!("Total iterations: {total_iterations}");
+    println!("Total time: {total_time:?}");
+    println!("Iterations per second: {iterations_per_second}");
+    println!("Average game length: {average_game_length}");
 
     // if let Ok(report) = guard.report().build() {
     //     let file = File::create("target/flamegraph.svg").unwrap();

--- a/fixtures/stacked_hazards.json
+++ b/fixtures/stacked_hazards.json
@@ -16,7 +16,7 @@
         "id": "gs_vbvwfwk6jBc4jmCrKCbdJh3G",
         "name": "does this work lol (unstable)",
         "latency": "204",
-        "health": 99,
+        "health": 100,
         "body": [
           {
             "x": 5,
@@ -48,6 +48,14 @@
       {
         "x": 0,
         "y": 0
+      },
+      {
+        "x": 5,
+        "y": 7
+      },
+      {
+        "x": 5,
+        "y": 7
       }
     ]
   },

--- a/fixtures/stacked_hazards.json
+++ b/fixtures/stacked_hazards.json
@@ -1,0 +1,80 @@
+{
+  "game": {
+    "id": "506514ef-249f-48b8-827b-7bf8d17ac7ad",
+    "ruleset": {
+      "name": "royale",
+      "version": "v1.0.20"
+    },
+    "timeout": 600
+  },
+  "turn": 1,
+  "board": {
+    "height": 11,
+    "width": 11,
+    "snakes": [
+      {
+        "id": "gs_vbvwfwk6jBc4jmCrKCbdJh3G",
+        "name": "does this work lol (unstable)",
+        "latency": "204",
+        "health": 99,
+        "body": [
+          {
+            "x": 5,
+            "y": 8
+          },
+          {
+            "x": 5,
+            "y": 9
+          },
+          {
+            "x": 5,
+            "y": 9
+          }
+        ],
+        "head": {
+          "x": 5,
+          "y": 8
+        },
+        "length": 3,
+        "shout": ""
+      }
+    ],
+    "food": [],
+    "hazards": [
+      {
+        "x": 0,
+        "y": 0
+      },
+      {
+        "x": 0,
+        "y": 0
+      }
+    ]
+  },
+  "you": {
+    "id": "gs_vbvwfwk6jBc4jmCrKCbdJh3G",
+    "name": "does this work lol (unstable)",
+    "latency": "204",
+    "health": 99,
+    "body": [
+      {
+        "x": 5,
+        "y": 8
+      },
+      {
+        "x": 5,
+        "y": 9
+      },
+      {
+        "x": 5,
+        "y": 9
+      }
+    ],
+    "head": {
+      "x": 5,
+      "y": 8
+    },
+    "length": 3,
+    "shout": ""
+  }
+}

--- a/fixtures/start_of_game.json
+++ b/fixtures/start_of_game.json
@@ -1,1 +1,170 @@
-{"game":{"id":"506514ef-249f-48b8-827b-7bf8d17ac7ad","ruleset":{"name":"royale","version":"v1.0.20"},"timeout":600},"turn":1,"board":{"height":11,"width":11,"snakes":[{"id":"gs_YkwKKSmYwqFFgDk9BycMvWf8","name":"PepperLongStocking🧦","latency":"370","health":99,"body":[{"x":0,"y":5},{"x":1,"y":5},{"x":1,"y":5}],"head":{"x":0,"y":5},"length":3,"shout":"0: 100 - 3"},{"id":"gs_vbvwfwk6jBc4jmCrKCbdJh3G","name":"does this work lol (unstable)","latency":"204","health":99,"body":[{"x":5,"y":8},{"x":5,"y":9},{"x":5,"y":9}],"head":{"x":5,"y":8},"length":3,"shout":""},{"id":"gs_6QpMpVPy7RpRxvcC9cc9V3xF","name":"Gaius Imperattlesnake","latency":"269","health":99,"body":[{"x":4,"y":1},{"x":5,"y":1},{"x":5,"y":1}],"head":{"x":4,"y":1},"length":3,"shout":""},{"id":"gs_6kQVWJXt9BFpD6dchrmX8qpM","name":"Nessegrev-beta","latency":"454","health":99,"body":[{"x":9,"y":0},{"x":9,"y":1},{"x":9,"y":1}],"head":{"x":9,"y":0},"length":3,"shout":""}],"food":[{"x":0,"y":4},{"x":4,"y":8},{"x":4,"y":0},{"x":8,"y":0},{"x":5,"y":5}],"hazards":[]},"you":{"id":"gs_vbvwfwk6jBc4jmCrKCbdJh3G","name":"does this work lol (unstable)","latency":"204","health":99,"body":[{"x":5,"y":8},{"x":5,"y":9},{"x":5,"y":9}],"head":{"x":5,"y":8},"length":3,"shout":""}}
+{
+  "game": {
+    "id": "506514ef-249f-48b8-827b-7bf8d17ac7ad",
+    "ruleset": {
+      "name": "royale",
+      "version": "v1.0.20"
+    },
+    "timeout": 600
+  },
+  "turn": 1,
+  "board": {
+    "height": 11,
+    "width": 11,
+    "snakes": [
+      {
+        "id": "gs_YkwKKSmYwqFFgDk9BycMvWf8",
+        "name": "PepperLongStocking🧦",
+        "latency": "370",
+        "health": 99,
+        "body": [
+          {
+            "x": 0,
+            "y": 5
+          },
+          {
+            "x": 1,
+            "y": 5
+          },
+          {
+            "x": 1,
+            "y": 5
+          }
+        ],
+        "head": {
+          "x": 0,
+          "y": 5
+        },
+        "length": 3,
+        "shout": "0: 100 - 3"
+      },
+      {
+        "id": "gs_vbvwfwk6jBc4jmCrKCbdJh3G",
+        "name": "does this work lol (unstable)",
+        "latency": "204",
+        "health": 99,
+        "body": [
+          {
+            "x": 5,
+            "y": 8
+          },
+          {
+            "x": 5,
+            "y": 9
+          },
+          {
+            "x": 5,
+            "y": 9
+          }
+        ],
+        "head": {
+          "x": 5,
+          "y": 8
+        },
+        "length": 3,
+        "shout": ""
+      },
+      {
+        "id": "gs_6QpMpVPy7RpRxvcC9cc9V3xF",
+        "name": "Gaius Imperattlesnake",
+        "latency": "269",
+        "health": 99,
+        "body": [
+          {
+            "x": 4,
+            "y": 1
+          },
+          {
+            "x": 5,
+            "y": 1
+          },
+          {
+            "x": 5,
+            "y": 1
+          }
+        ],
+        "head": {
+          "x": 4,
+          "y": 1
+        },
+        "length": 3,
+        "shout": ""
+      },
+      {
+        "id": "gs_6kQVWJXt9BFpD6dchrmX8qpM",
+        "name": "Nessegrev-beta",
+        "latency": "454",
+        "health": 99,
+        "body": [
+          {
+            "x": 9,
+            "y": 0
+          },
+          {
+            "x": 9,
+            "y": 1
+          },
+          {
+            "x": 9,
+            "y": 1
+          }
+        ],
+        "head": {
+          "x": 9,
+          "y": 0
+        },
+        "length": 3,
+        "shout": ""
+      }
+    ],
+    "food": [
+      {
+        "x": 0,
+        "y": 4
+      },
+      {
+        "x": 4,
+        "y": 8
+      },
+      {
+        "x": 4,
+        "y": 0
+      },
+      {
+        "x": 8,
+        "y": 0
+      },
+      {
+        "x": 5,
+        "y": 5
+      }
+    ],
+    "hazards": []
+  },
+  "you": {
+    "id": "gs_vbvwfwk6jBc4jmCrKCbdJh3G",
+    "name": "does this work lol (unstable)",
+    "latency": "204",
+    "health": 99,
+    "body": [
+      {
+        "x": 5,
+        "y": 8
+      },
+      {
+        "x": 5,
+        "y": 9
+      },
+      {
+        "x": 5,
+        "y": 9
+      }
+    ],
+    "head": {
+      "x": 5,
+      "y": 8
+    },
+    "length": 3,
+    "shout": ""
+  }
+}

--- a/src/compact_representation/core/cell_board/eval.rs
+++ b/src/compact_representation/core/cell_board/eval.rs
@@ -117,7 +117,7 @@ impl<T: CellNum, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize
                     while curr != old_head {
                         prev = curr;
                         curr = self.get_cell(curr).get_next_index().unwrap_or_else(|| {
-                            eprintln!("{}", self);
+                            eprintln!("{self}");
                             panic!("snake is inconsistent")
                         });
                     }

--- a/src/compact_representation/core/cell_board/eval.rs
+++ b/src/compact_representation/core/cell_board/eval.rs
@@ -5,7 +5,7 @@ use tracing::instrument;
 
 use crate::{
     compact_representation::{core::dimensions::Dimensions, CellNum},
-    types::{self, HeadGettableGame, Move, SnakeId, N_MOVES},
+    types::{self, HazardQueryableGame, HeadGettableGame, Move, SnakeId, N_MOVES},
 };
 
 use super::{CellBoard, CellIndex};
@@ -139,9 +139,8 @@ impl<T: CellNum, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize
 
                 let mut new_health = self.healths[id.as_usize()];
                 new_health = new_health.saturating_sub(1);
-                if self.get_cell(new_head).is_hazard() {
-                    new_health = new_health.saturating_sub(self.hazard_damage);
-                }
+                let hazard_damange = self.get_hazard_damage_at(&new_head);
+                new_health = new_health.saturating_sub(hazard_damange);
 
                 let ate_food = self.get_cell(new_head).is_food();
                 let mut new_length = self.lengths[id.as_usize()];

--- a/src/compact_representation/core/cell_board/hazard_queryable.rs
+++ b/src/compact_representation/core/cell_board/hazard_queryable.rs
@@ -15,4 +15,8 @@ impl<T: CellNum, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize
     fn get_hazard_damage(&self) -> u8 {
         self.hazard_damage
     }
+
+    fn get_hazard_count(&self, pos: &Self::NativePositionType) -> u8 {
+        self.cell_hazard_count(*pos)
+    }
 }

--- a/src/compact_representation/core/cell_board/mod.rs
+++ b/src/compact_representation/core/cell_board/mod.rs
@@ -412,6 +412,10 @@ impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
         self.get_cell(cell_idx).is_hazard()
     }
 
+    fn cell_hazard_count(&self, cell_idx: CellIndex<T>) -> u8 {
+        self.get_cell(cell_idx).hazard_count()
+    }
+
     /// determines if this cell is a snake head (including triple stacked)
     pub fn cell_is_snake_head(&self, cell_idx: CellIndex<T>) -> bool {
         self.get_cell(cell_idx).is_head()

--- a/src/compact_representation/core/impl_common.rs
+++ b/src/compact_representation/core/impl_common.rs
@@ -104,12 +104,12 @@ macro_rules! impl_common_board_traits {
         impl<T: CN, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize>
             HazardQueryableGame for $type<T, D, BOARD_SIZE, MAX_SNAKES>
         {
-            fn is_hazard(&self, pos: &Self::NativePositionType) -> bool {
-                self.embedded.is_hazard(pos)
-            }
-
             fn get_hazard_damage(&self) -> u8 {
                 self.embedded.get_hazard_damage()
+            }
+
+            fn get_hazard_count(&self, pos: &Self::NativePositionType) -> u8 {
+                self.embedded.get_hazard_count(pos)
             }
         }
 

--- a/src/compact_representation/core/mod.rs
+++ b/src/compact_representation/core/mod.rs
@@ -138,8 +138,12 @@ impl<T: CellNum> Cell<T> {
 
     #[allow(dead_code)]
     pub fn set_hazard_count(&mut self, count: u8) {
-        self.flags |= IS_HAZARD;
-        self.hazard_count = count;
+        if count == 0 {
+            self.clear_hazard();
+        } else {
+            self.flags |= IS_HAZARD;
+            self.hazard_count = count;
+        }
     }
 
     pub fn clear_hazard(&mut self) {

--- a/src/compact_representation/core/simulate.rs
+++ b/src/compact_representation/core/simulate.rs
@@ -68,10 +68,7 @@ where
 
         let game = board.evaluate_moves_with_state(m.iter(), &states);
         if !game.assert_consistency() {
-            panic!(
-                "caught an inconsistent simulate, moves: {:?} orig: {}, new: {}",
-                m, board, game
-            );
+            panic!("caught an inconsistent simulate, moves: {m:?} orig: {board}, new: {game}");
         }
         (action, game)
     });

--- a/src/compact_representation/standard/mod.rs
+++ b/src/compact_representation/standard/mod.rs
@@ -352,13 +352,13 @@ mod test {
             Move::Down,
         ];
         let instruments = Instruments;
-        eprintln!("{}", compact);
+        eprintln!("{compact}");
         for mv in moves {
             let res = compact
                 .simulate_with_moves(&instruments, vec![(SnakeId(0), [mv].as_slice())])
                 .collect_vec();
             compact = res[0].1;
-            eprintln!("{}", compact);
+            eprintln!("{compact}");
         }
         assert!(compact.get_health(&SnakeId(0)) > 0);
     }

--- a/src/compact_representation/standard/mod.rs
+++ b/src/compact_representation/standard/mod.rs
@@ -518,4 +518,42 @@ mod test {
 
         assert_eq!(reasonable_moves_for_me, vec![Move::Up]);
     }
+
+    #[test]
+    fn test_simulate_stacked_hazards() {
+        let game_fixture = include_str!("../../../fixtures/stacked_hazards.json");
+        let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+        let g = g.expect("the json literal is valid");
+        let snake_id_mapping = build_snake_id_map(&g);
+        let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+
+        let moves = vec![(SnakeId(0), vec![Move::Down])];
+
+        let result = compact
+            .simulate_with_moves(&Instruments {}, moves)
+            .next()
+            .unwrap()
+            .1;
+
+        assert_eq!(result.get_health(&SnakeId(0)), 69);
+    }
+
+    #[test]
+    fn test_simulate_stacked_hazards_no_hazard_on_sqaure() {
+        let game_fixture = include_str!("../../../fixtures/stacked_hazards.json");
+        let g: Result<DEGame, _> = serde_json::from_slice(game_fixture.as_bytes());
+        let g = g.expect("the json literal is valid");
+        let snake_id_mapping = build_snake_id_map(&g);
+        let compact: CellBoard4Snakes11x11 = g.as_cell_board(&snake_id_mapping).unwrap();
+
+        let moves = vec![(SnakeId(0), vec![Move::Right])];
+
+        let result = compact
+            .simulate_with_moves(&Instruments {}, moves)
+            .next()
+            .unwrap()
+            .1;
+
+        assert_eq!(result.get_health(&SnakeId(0)), 99);
+    }
 }

--- a/src/compact_representation/wrapped/mod.rs
+++ b/src/compact_representation/wrapped/mod.rs
@@ -482,17 +482,14 @@ mod test {
             let hm = serde_json::from_str(json_hash).unwrap();
             let game = super::CellBoard4SnakesSquare11x11::from_packed_hash(&hm);
             game.assert_consistency();
-            eprintln!(
-                "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!1\n{}",
-                game
-            );
+            eprintln!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!1\n{game}");
             let mut results = game
                 .simulate_with_moves(&instruments, snakes_and_moves)
                 .collect_vec();
             assert!(results.len() == 1);
             let (mvs, g) = results.pop().unwrap();
             dbg!(mvs);
-            eprintln!("{}", g);
+            eprintln!("{g}");
             g.assert_consistency();
             g.simulate(&instruments, compact_ids.clone()).for_each(drop);
         }
@@ -506,17 +503,14 @@ mod test {
             let hm = serde_json::from_str(json_hash).unwrap();
             let game = super::CellBoard4SnakesSquare11x11::from_packed_hash(&hm);
             game.assert_consistency();
-            eprintln!(
-                "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!1\n{}",
-                game
-            );
+            eprintln!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!1\n{game}");
             let mut results = game
                 .simulate_with_moves(&instruments, snakes_and_moves)
                 .collect_vec();
             assert!(results.len() == 1);
             let (mvs, g) = results.pop().unwrap();
             dbg!(mvs);
-            eprintln!("{}", g);
+            eprintln!("{g}");
             // head to head collision of 0 and 1 here
             assert_eq!(g.get_health(&SnakeId(0)), 0);
             assert_eq!(g.get_health(&SnakeId(1)), 0);

--- a/src/hazard_algorithms/mod.rs
+++ b/src/hazard_algorithms/mod.rs
@@ -328,9 +328,9 @@ mod tests {
         let mut maintained_hazards = HashSet::new();
         let mut hazard_alg = SpiralHazard::new();
         let self_file = path::Path::new(env!("CARGO_MANIFEST_DIR"));
-        eprintln!("{:?}", self_file);
+        eprintln!("{self_file:?}");
         for i in 1..=193 {
-            let file_name = self_file.join(format!("fixtures/debug_wrapped/debug_game_{}.json", i));
+            let file_name = self_file.join(format!("fixtures/debug_wrapped/debug_game_{i}.json"));
             let file_bytes = fs::read(file_name).unwrap();
             let game: Game = serde_json::from_slice(&file_bytes).unwrap();
 

--- a/src/hazard_algorithms/mod.rs
+++ b/src/hazard_algorithms/mod.rs
@@ -190,8 +190,7 @@ impl ForwardOnlyHazardAlgorithm<Position> for SpiralHazard {
             {
                 debug_assert!(
                     is_perfect_odd_square(spawns_elapsed + 1),
-                    "spawns_elapsed: {}",
-                    spawns_elapsed
+                    "spawns_elapsed: {spawns_elapsed}"
                 );
                 self.direction = Move::Up;
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -286,10 +286,24 @@ pub trait SimulableGame<T: SimulatorInstruments, const N_SNAKES: usize>:
 /// A game where positions can be checked for hazards
 pub trait HazardQueryableGame: PositionGettableGame {
     /// Is this position a hazard?
-    fn is_hazard(&self, pos: &Self::NativePositionType) -> bool;
+    fn is_hazard(&self, pos: &Self::NativePositionType) -> bool {
+        self.get_hazard_count(pos) > 0
+    }
 
     /// how much damage do hazards do?
     fn get_hazard_damage(&self) -> u8;
+
+    /// Get the total damage at a given position
+    fn get_hazard_damage_at(&self, pos: &Self::NativePositionType) -> u8 {
+        if self.is_hazard(pos) {
+            self.get_hazard_damage() * self.get_hazard_count(pos)
+        } else {
+            0
+        }
+    }
+
+    /// Get the count of hazards stacked on a given position
+    fn get_hazard_count(&self, pos: &Self::NativePositionType) -> u8;
 }
 
 /// A game where positions can be checked for food

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -504,10 +504,6 @@ impl SnakeBodyGettableGame for Game {
 }
 
 impl HazardQueryableGame for Game {
-    fn is_hazard(&self, pos: &Self::NativePositionType) -> bool {
-        self.board.hazards.contains(pos)
-    }
-
     fn get_hazard_damage(&self) -> u8 {
         self.game
             .ruleset
@@ -515,6 +511,10 @@ impl HazardQueryableGame for Game {
             .as_ref()
             .map(|settings| settings.hazard_damage_per_turn)
             .unwrap_or(15) as u8
+    }
+
+    fn get_hazard_count(&self, pos: &Self::NativePositionType) -> u8 {
+        self.board.hazards.iter().filter(|p| p == &pos).count() as u8
     }
 }
 


### PR DESCRIPTION
For the upcoming Community Tournament we are going to be playing Snail Mode!

Snail Mode is currently implemented with **Stacked Hazards**, where there may be more than 1 hazard on any given square

This PR makes the necessary changes to run simulations with the Stacked Hazards logic